### PR TITLE
feat(core): enumerate audio devices via python ipc

### DIFF
--- a/src-python/audio_capture.py
+++ b/src-python/audio_capture.py
@@ -4,14 +4,44 @@ import os
 import threading
 import wave
 import numpy as np
-from abc import ABC, abstractmethod
-from vad_service import VADService
-
-import sys
 if sys.platform == "win32":
     import pyaudiowpatch as pyaudio
 else:
     import pyaudio
+from abc import ABC, abstractmethod
+from vad_service import VADService
+
+
+def list_audio_devices() -> list:
+    """
+    Returns a list of available audio input devices on the current platform.
+    Each entry: {id, name, type}  where type is 'mic' or 'loopback'.
+    Safe to call at any time — opens and closes PyAudio internally.
+    """
+    devices = []
+    try:
+        p = pyaudio.PyAudio()
+        count = p.get_device_count()
+        for i in range(count):
+            try:
+                info = p.get_device_info_by_index(i)
+                if info.get("maxInputChannels", 0) < 1:
+                    continue
+                name = info.get("name", f"Device {i}")
+                # On Windows with pyaudiowpatch, loopback devices have
+                # 'Loopback' in the name or come from the wasapi loopback API.
+                is_loopback = "loopback" in name.lower()
+                devices.append({
+                    "id": i,
+                    "name": name,
+                    "type": "loopback" if is_loopback else "mic",
+                })
+            except Exception:
+                continue
+        p.terminate()
+    except Exception as e:
+        print(f"DEBUG: [AudioDevices] Failed to enumerate devices: {e}", file=sys.stderr)
+    return devices
 
 # ---------------------------------------------------------
 # STRATEGY PATTERN: The abstract interface

--- a/src-python/main.py
+++ b/src-python/main.py
@@ -4,7 +4,7 @@ import json
 import time
 
 # Internal services
-from audio_capture import AudioCaptureFactory
+from audio_capture import AudioCaptureFactory, list_audio_devices
 from transcription_service import TranscriptionService
 from llm_service import LLMFactory
 
@@ -20,6 +20,7 @@ def main():
     # Allow React time to mount and start listening to IPC events
     time.sleep(2)
     send_event("SYSTEM_READY", {"status": "Python engine is ready and listening."})
+    send_event("DEVICE_LIST", {"devices": list_audio_devices()})
 
     # 1. Initialize Audio Capture
     try:
@@ -41,7 +42,10 @@ def main():
             command = json.loads(line.strip())
             action = command.get("action")
 
-            if action == "START_RECORDING":
+            if action == "LIST_DEVICES":
+                send_event("DEVICE_LIST", {"devices": list_audio_devices()})
+
+            elif action == "START_RECORDING":
                 send_event("RECORDING_STATUS", {"is_recording": True})
                 audio_capturer.start_recording()
                 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::process::{ChildStdin, Command, Stdio};
 use std::sync::{Arc, Mutex};
-use tauri::{AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
+use tauri::{AppHandle, Emitter, Manager, State, WebviewWindowBuilder, WebviewUrl};
 use tauri::{LogicalSize, Window};
 
 // 1. Structure Definitions
@@ -78,9 +78,7 @@ fn send_command_to_python(state: State<'_, AppState>, payload: String) -> Result
 
 #[tauri::command]
 async fn set_compact_mode(window: Window) -> Result<(), String> {
-    window
-        .set_size(LogicalSize::new(400.0, 120.0))
-        .map_err(|e| e.to_string())?;
+    window.set_size(LogicalSize::new(400.0, 120.0)).map_err(|e| e.to_string())?;
     window.set_decorations(false).map_err(|e| e.to_string())?;
     window.set_always_on_top(true).map_err(|e| e.to_string())?;
     window.set_resizable(false).map_err(|e| e.to_string())?;
@@ -89,17 +87,31 @@ async fn set_compact_mode(window: Window) -> Result<(), String> {
 
 #[tauri::command]
 async fn set_expanded_mode(window: Window) -> Result<(), String> {
-    window
-        .set_size(LogicalSize::new(1024.0, 720.0))
-        .map_err(|e| e.to_string())?;
-    window.set_decorations(false).map_err(|e| e.to_string())?;
+    window.set_size(LogicalSize::new(1024.0, 720.0)).map_err(|e| e.to_string())?;
+    window.set_decorations(true).map_err(|e| e.to_string())?;
     window.set_always_on_top(false).map_err(|e| e.to_string())?;
     window.set_resizable(true).map_err(|e| e.to_string())?;
     window.center().map_err(|e| e.to_string())?;
     Ok(())
 }
 
-// 5. Popover Window Commands
+// 5. Audio Device Enumeration
+// Sends LIST_DEVICES to Python and waits for the DEVICE_LIST event.
+// The event is already forwarded to React by the stdout reader thread,
+// so the frontend just needs to listen for "python-event" with DEVICE_LIST.
+// This command is a fire-and-forget trigger — no return value needed.
+#[tauri::command]
+fn request_audio_devices(state: State<'_, AppState>) -> Result<(), String> {
+    let stdin_lock = state.python_stdin.lock().unwrap();
+    if let Some(mut stdin) = stdin_lock.as_ref() {
+        let payload = serde_json::json!({"action": "LIST_DEVICES"});
+        writeln!(stdin, "{}", payload).map_err(|e| e.to_string())?;
+        return Ok(());
+    }
+    Err("Python process not available".to_string())
+}
+
+// 6. Popover Window Commands
 //
 // Opens the settings popover as a separate frameless OS window, positioned
 // above the compact widget. If the window is already open, closes it (toggle).
@@ -170,8 +182,7 @@ pub fn run() {
             markdown_summary TEXT NOT NULL
         )",
         [],
-    )
-    .expect("Failed to create tables");
+    ).expect("Failed to create tables");
 
     let python_stdin = Arc::new(Mutex::new(None));
     let python_stdin_clone = Arc::clone(&python_stdin);
@@ -189,9 +200,9 @@ pub fn run() {
         .setup(move |app| {
             let app_handle = app.handle().clone();
 
-            let mut child = Command::new("bash")
+            let mut child = Command::new("python")
                 .current_dir("../")
-                .arg("src-python/run.sh")
+                .arg("src-python/main.py")
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
@@ -222,6 +233,7 @@ pub fn run() {
             set_expanded_mode,
             open_popover_window,
             close_popover_window,
+            request_audio_devices,
         ])
         .run(tauri::generate_context!())
         .expect("Error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -221,6 +221,12 @@ function Toggle({ on, onChange }: { on: boolean; onChange: (v: boolean) => void 
   );
 }
 
+interface AudioDevice {
+  id: number;
+  name: string;
+  type: "mic" | "loopback";
+}
+
 // ── Popover Window Content ────────────────────────────────────
 // Rendered when window label is "popover". Self-contained: loads settings
 // from store, emits "settings-changed" on save, closes itself on blur.
@@ -229,6 +235,8 @@ function PopoverWindowContent() {
   const [modelName, setModelName] = useState("llama3");
   const [apiKey, setApiKey] = useState("");
   const [theme, setTheme] = useState("liquid-glass");
+  const [devices, setDevices] = useState<AudioDevice[]>([]);
+  const [selectedDevice, setSelectedDevice] = useState<number | null>(null);
   const isLG = theme !== "minimalist-notebook";
   const win = getCurrentWindow();
 
@@ -241,15 +249,32 @@ function PopoverWindowContent() {
         const sm = await store.get<string>("modelName");
         const sk = await store.get<string>("apiKey");
         const st = await store.get<string>("theme");
+        const sd = await store.get<number>("selectedDeviceId");
         if (sp) setProvider(sp);
         if (sm) setModelName(sm);
         if (sk) setApiKey(sk);
         if (st) setTheme(st);
+        if (sd != null) setSelectedDevice(sd);
       } catch (e) {
         console.error("Failed to load settings in popover:", e);
       }
     };
     init();
+    // Request device list from Python
+    invoke("request_audio_devices").catch(console.error);
+  }, []);
+
+  // Listen for DEVICE_LIST events from Python (forwarded by Rust stdout reader)
+  useEffect(() => {
+    const unlisten = listen<string>("python-event", (event) => {
+      try {
+        const parsed = JSON.parse(event.payload);
+        if (parsed.event === "DEVICE_LIST") {
+          setDevices(parsed.data.devices ?? []);
+        }
+      } catch {}
+    });
+    return () => { unlisten.then((f) => f()); };
   }, []);
 
   // Keep data-theme in sync for correct CSS variables
@@ -278,8 +303,8 @@ function PopoverWindowContent() {
       await store.set("modelName", modelName);
       await store.set("apiKey", apiKey);
       await store.set("theme", theme);
+      if (selectedDevice !== null) await store.set("selectedDeviceId", selectedDevice);
       await store.save();
-      // Broadcast to all windows (main window listens for this)
       await emit("settings-changed", { provider, modelName, apiKey, theme } satisfies SettingsPayload);
       await win.close();
     } catch (e) {
@@ -296,6 +321,25 @@ function PopoverWindowContent() {
       <div className="popover-drag-handle" data-tauri-drag-region />
 
       <div className="popover-label">SETTINGS</div>
+
+      {/* Input device picker */}
+      <div className="popover-row">
+        <label className="popover-row-label">Input</label>
+        <select
+          className="popover-select"
+          value={selectedDevice ?? ""}
+          onChange={(e) => setSelectedDevice(Number(e.target.value))}
+        >
+          {devices.length === 0 && (
+            <option value="">Loading devices…</option>
+          )}
+          {devices.map((d) => (
+            <option key={d.id} value={d.id}>
+              {d.name}{d.type === "loopback" ? " (loopback)" : ""}
+            </option>
+          ))}
+        </select>
+      </div>
 
       {/* Provider */}
       <div className="popover-row">


### PR DESCRIPTION
- Add list_audio_devices() to audio_capture.py (cross-platform)
- Fix pyaudio import: pyaudiowpatch on Windows, pyaudio on macOS
- Emit DEVICE_LIST on startup and handle LIST_DEVICES command in main.py
- Add request_audio_devices Rust command in lib.rs
- Add device picker select to PopoverWindowContent in App.tsx