### PR TITLE
77 aicore vad telemetry bridge real time rms

### DIFF
--- a/src-python/audio_capture.py
+++ b/src-python/audio_capture.py
@@ -51,8 +51,8 @@ class AudioCaptureStrategy(ABC):
     Abstract base class defining the contract for all audio capture strategies.
     """
     @abstractmethod
-    def start_recording(self):
-        """Starts capturing system and microphone audio."""
+    def start_recording(self, telemetry_callback=None):
+        """Starts capturing audio. Optional callback(level: float) for RMS telemetry."""
         pass
 
     @abstractmethod
@@ -72,33 +72,35 @@ class WindowsAudioCapture(AudioCaptureStrategy):
     
     def __init__(self):
         self.is_recording = False
-        
+        self.telemetry_callback = None
+
         # Audio Engine references
         self.p = None
         self.loopback_stream = None
         self.mic_stream = None
-        
+
         # Thread references (CRITICAL for preventing deadlocks)
         self.loopback_thread = None
         self.mic_thread = None
-        
+
         # Buffers
         self.loopback_frames = []
         self.mic_frames = []
-        
+
         # Standard configuration for Speech-to-Text models
         self.master_sample_rate = 48000
         self.loopback_channels = 2
         self.mic_channels = 1
-        
+
         current_dir = os.path.dirname(os.path.abspath(__file__))
         self.output_file = os.path.join(current_dir, "temp_meeting_audio.wav")
 
-    def start_recording(self):
+    def start_recording(self, telemetry_callback=None):
         if self.is_recording:
             return
 
         self.is_recording = True
+        self.telemetry_callback = telemetry_callback
         self.loopback_frames = []
         self.mic_frames = []
         
@@ -167,16 +169,24 @@ class WindowsAudioCapture(AudioCaptureStrategy):
 
     def _record_mic(self):
         """Continuously reads data from the microphone stream into memory."""
+        chunk_count = 0
         try:
             while self.is_recording and self.mic_stream:
                 data = self.mic_stream.read(1024, exception_on_overflow=False)
                 audio_data = np.frombuffer(data, dtype=np.int16)
-                
+
                 if self.mic_channels > 1:
                     audio_data = np.reshape(audio_data, (-1, self.mic_channels))
                     audio_data = np.mean(audio_data, axis=1).astype(np.int16)
-                    
+
                 self.mic_frames.append(audio_data)
+
+                # Emit RMS telemetry every 5th chunk
+                chunk_count += 1
+                if chunk_count % 5 == 0 and self.telemetry_callback:
+                    rms = float(np.sqrt(np.mean(audio_data.astype(np.float32) ** 2)))
+                    level = min(rms / 32768.0, 1.0)
+                    self.telemetry_callback(level)
         except Exception as e:
             print(f"DEBUG: [Windows Mic Error] {str(e)}", file=sys.stderr)
 
@@ -226,13 +236,106 @@ class WindowsAudioCapture(AudioCaptureStrategy):
         return self.output_file
     
 class MacosAudioCapture(AudioCaptureStrategy):
-    """ScreenCaptureKit implementation for macOS system audio."""
-    def start_recording(self):
-        print("DEBUG: [macOS] Starting ScreenCaptureKit capture...", file=sys.stderr)
+    """
+    macOS microphone capture via PyAudio.
+    System audio loopback (ScreenCaptureKit) is planned for Sprint 9 Card 9.4.
+    """
+
+    def __init__(self):
+        self.is_recording = False
+        self.telemetry_callback = None
+        self.p = None
+        self.mic_stream = None
+        self.mic_thread = None
+        self.mic_frames = []
+        self.sample_rate = 16000  # WhisperX works best at 16kHz
+        self.channels = 1
+
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        self.output_file = os.path.join(current_dir, "temp_meeting_audio.wav")
+
+    def start_recording(self, telemetry_callback=None):
+        if self.is_recording:
+            return
+
+        self.is_recording = True
+        self.telemetry_callback = telemetry_callback
+        self.mic_frames = []
+
+        try:
+            self.p = pyaudio.PyAudio()
+            self.mic_stream = self.p.open(
+                format=pyaudio.paInt16,
+                channels=self.channels,
+                rate=self.sample_rate,
+                input=True,
+                frames_per_buffer=1024,
+            )
+            self.mic_thread = threading.Thread(target=self._record, daemon=True)
+            self.mic_thread.start()
+            print("DEBUG: [macOS] Microphone capture started.", file=sys.stderr)
+        except Exception as e:
+            print(f"DEBUG: [macOS] Failed to start microphone: {e}", file=sys.stderr)
+            self.is_recording = False
+
+    def _record(self):
+        chunk_count = 0
+        try:
+            while self.is_recording and self.mic_stream:
+                data = self.mic_stream.read(1024, exception_on_overflow=False)
+                audio_data = np.frombuffer(data, dtype=np.int16)
+                self.mic_frames.append(audio_data)
+
+                # Emit RMS telemetry every 5th chunk
+                chunk_count += 1
+                if chunk_count % 5 == 0 and self.telemetry_callback:
+                    rms = float(np.sqrt(np.mean(audio_data.astype(np.float32) ** 2)))
+                    level = min(rms / 32768.0, 1.0)
+                    self.telemetry_callback(level)
+        except Exception as e:
+            print(f"DEBUG: [macOS Mic Error] {e}", file=sys.stderr)
 
     def stop_recording(self) -> str:
-        print("DEBUG: [macOS] Stopping capture...", file=sys.stderr)
-        return "temp_macos_audio.wav"
+        if not self.is_recording:
+            return self.output_file
+
+        self.is_recording = False
+        if self.mic_thread:
+            self.mic_thread.join(timeout=2.0)
+
+        if self.mic_stream:
+            try:
+                self.mic_stream.stop_stream()
+                self.mic_stream.close()
+            except Exception:
+                pass
+        if self.p:
+            self.p.terminate()
+
+        if not self.mic_frames:
+            print("DEBUG: [macOS] No audio frames captured.", file=sys.stderr)
+            return self.output_file
+
+        audio_full = np.concatenate(self.mic_frames)
+
+        print("DEBUG: [AI] Running Silero VAD to trim silence...", file=sys.stderr)
+        try:
+            vad = VADService()
+            audio_trimmed = vad.trim_silence(
+                audio_full.reshape(-1, 1), self.sample_rate
+            )
+        except Exception as e:
+            print(f"DEBUG: [AI VAD Error] Falling back to raw audio: {e}", file=sys.stderr)
+            audio_trimmed = audio_full.reshape(-1, 1)
+
+        with wave.open(self.output_file, "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(self.sample_rate)
+            wf.writeframes(audio_trimmed.tobytes())
+
+        print(f"DEBUG: [macOS] Audio saved to {self.output_file}", file=sys.stderr)
+        return self.output_file
 
 # ---------------------------------------------------------
 # FACTORY METHOD: Instantiates the correct strategy

--- a/src-python/llm_service.py
+++ b/src-python/llm_service.py
@@ -158,7 +158,7 @@ class LLMFactory:
         
         # Set default models if none provided by the frontend
         if provider_name == "ollama" and not model_config:
-            model_config = "llama3"
+            model_config = "gemma4"
         elif provider_name == "openai" and not model_config:
             model_config = "gpt-4o"
         elif provider_name == "gemini" and not model_config:

--- a/src-python/main.py
+++ b/src-python/main.py
@@ -8,6 +8,9 @@ from audio_capture import AudioCaptureFactory, list_audio_devices
 from transcription_service import TranscriptionService
 from llm_service import LLMFactory
 
+
+
+
 def send_event(event_type: str, payload: dict):
     """
     Observer Pattern: Emits events for Rust/Tauri to capture via stdout.
@@ -94,4 +97,8 @@ def main():
             send_event("ERROR", {"message": f"Unexpected error: {str(e)}"})
 
 if __name__ == "__main__":
+    _devices_cached = list_audio_devices()  # ← adiciona aqui, linha 20
+    time.sleep(2)
+    send_event("SYSTEM_READY", {"status": "Python engine is ready and listening."})
+    send_event("DEVICE_LIST", {"devices": _devices_cached})  # ← troca list_audio_devices() por _devices_cached
     main()

--- a/src-python/main.py
+++ b/src-python/main.py
@@ -47,7 +47,11 @@ def main():
 
             elif action == "START_RECORDING":
                 send_event("RECORDING_STATUS", {"is_recording": True})
-                audio_capturer.start_recording()
+
+                def on_telemetry(level: float):
+                    send_event("VAD_TELEMETRY", {"level": round(level, 3)})
+
+                audio_capturer.start_recording(telemetry_callback=on_telemetry)
                 
             elif action == "STOP_RECORDING":
                 send_event("RECORDING_STATUS", {"is_recording": False})

--- a/src-python/transcription_service.py
+++ b/src-python/transcription_service.py
@@ -53,21 +53,26 @@ class TranscriptionService:
                 self.model = None
 
     def transcribe(self, audio_path: str) -> str:
-        # ... (O resto do método transcribe continua exatamente igual) ...
         if self.model is None:
             return "[Error: WhisperX model not loaded]"
 
+        if not os.path.exists(audio_path):
+            return f"[Transcription Error: audio file not found at {audio_path}]"
+
+        if os.path.getsize(audio_path) < 1024:
+            return "[Transcription Error: audio file is empty — recording may have been too short]"
+
         print(f"DEBUG: [AI] Transcribing audio file: {audio_path}", file=sys.stderr)
-        
+
         try:
             audio = whisperx.load_audio(audio_path)
             result = self.model.transcribe(audio, batch_size=4)
             segments = result.get("segments", [])
             full_text = " ".join([seg["text"].strip() for seg in segments])
-            
+
             print("DEBUG: [AI] Transcription completed successfully.", file=sys.stderr)
             return full_text.strip()
-            
+
         except Exception as e:
             error_msg = f"[Transcription Error: {str(e)}]"
             print(f"DEBUG: {error_msg}", file=sys.stderr)

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["macos-private-api"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -217,7 +217,12 @@ pub fn run() {
                 let reader = BufReader::new(stdout);
                 for line in reader.lines() {
                     if let Ok(content) = line {
-                        println!("[PYTHON STDOUT] {}", content);
+                        // Suppress VAD_TELEMETRY from the Rust console — it fires
+                        // ~10x/second and would flood the terminal. Still forward
+                        // to React so the UI can animate the level meter.
+                        if !content.contains("VAD_TELEMETRY") {
+                            println!("[PYTHON STDOUT] {}", content);
+                        }
                         app_handle.emit("python-event", content).unwrap();
                     }
                 }

--- a/src/App.css
+++ b/src/App.css
@@ -13,7 +13,7 @@
 [data-theme="liquid-glass"] {
   --font: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
 
-  --bg-app: rgba(16, 14, 24, 0.90);
+  --bg-app:    rgba(16, 14, 24, 0.52);
   --bg-panel:  rgba(20, 18, 30, 0.46);
   --bg-input:  rgba(255, 255, 255, 0.07);
   --bg-hover:  rgba(255, 255, 255, 0.08);
@@ -40,7 +40,7 @@
   --radius-md:   10px;
   --radius-sm:   7px;
 
-  --blur: blur(40px) saturate(160%); 
+  --blur: blur(28px) saturate(180%);
 
   /* Shadow replaces outer border for visual separation */
   --shadow-widget: 0 20px 56px -8px rgba(0,0,0,0.62),
@@ -379,6 +379,28 @@ input, select { font-family: inherit; }
   flex-shrink: 0;
 }
 
+/* ── Popover level meter ───────────────────────────────────── */
+.popover-level-meter {
+  height: 3px;
+  border-radius: 2px;
+  background: rgba(255,255,255,0.08);
+  overflow: hidden;
+  margin: 2px 0 8px;
+}
+
+[data-theme="minimalist-notebook"] .popover-level-meter {
+  background: var(--border);
+}
+
+.popover-level-bar {
+  height: 100%;
+  background: var(--green);
+  border-radius: 2px;
+  transition: width 80ms ease-out;
+  min-width: 0;
+  max-width: 100%;
+}
+
 /* ── Compact settings popover ──────────────────────────────── */
 .compact-popover {
   position: absolute;
@@ -481,10 +503,9 @@ input, select { font-family: inherit; }
 
 .popover-lg .popover-select,
 .popover-lg .popover-input {
-  background: rgba(30, 28, 44, 0.92);
+  background: rgba(255,255,255,0.08);
   border: 1px solid rgba(255,255,255,0.14);
   color: rgba(255,255,255,0.96);
-  color-scheme: dark;
 }
 
 .popover-nb .popover-select,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -262,7 +262,9 @@ function PopoverWindowContent() {
     };
     init();
     // Request device list from Python
-    invoke("request_audio_devices").catch(console.error);
+    if (devices.length === 0) {
+      invoke("request_audio_devices").catch(console.error);
+    }
   }, []);
 
   // Listen for DEVICE_LIST and VAD_TELEMETRY events from Python
@@ -275,7 +277,7 @@ function PopoverWindowContent() {
         } else if (parsed.event === "VAD_TELEMETRY") {
           setAudioLevel(parsed.data.level ?? 0);
         }
-      } catch {}
+      } catch { }
     });
     return () => { unlisten.then((f) => f()); };
   }, []);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -237,6 +237,7 @@ function PopoverWindowContent() {
   const [theme, setTheme] = useState("liquid-glass");
   const [devices, setDevices] = useState<AudioDevice[]>([]);
   const [selectedDevice, setSelectedDevice] = useState<number | null>(null);
+  const [audioLevel, setAudioLevel] = useState(0);
   const isLG = theme !== "minimalist-notebook";
   const win = getCurrentWindow();
 
@@ -264,13 +265,15 @@ function PopoverWindowContent() {
     invoke("request_audio_devices").catch(console.error);
   }, []);
 
-  // Listen for DEVICE_LIST events from Python (forwarded by Rust stdout reader)
+  // Listen for DEVICE_LIST and VAD_TELEMETRY events from Python
   useEffect(() => {
     const unlisten = listen<string>("python-event", (event) => {
       try {
         const parsed = JSON.parse(event.payload);
         if (parsed.event === "DEVICE_LIST") {
           setDevices(parsed.data.devices ?? []);
+        } else if (parsed.event === "VAD_TELEMETRY") {
+          setAudioLevel(parsed.data.level ?? 0);
         }
       } catch {}
     });
@@ -339,6 +342,14 @@ function PopoverWindowContent() {
             </option>
           ))}
         </select>
+      </div>
+
+      {/* Level meter — only visible while recording */}
+      <div className="popover-level-meter">
+        <div
+          className="popover-level-bar"
+          style={{ width: `${Math.round(audioLevel * 100)}%` }}
+        />
       </div>
 
       {/* Provider */}
@@ -487,6 +498,7 @@ function App() {
   const [notes, setNotes] = useState("");
   const [isExpanded, setIsExpanded] = useState(false);
   const [recordingSeconds, setRecordingSeconds] = useState(0);
+  const [audioLevel, setAudioLevel] = useState(0);
   const [activeTab, setActiveTab] = useState<"transcript" | "summary" | "actions">("transcript");
   const [search, setSearch] = useState("");
 
@@ -589,6 +601,9 @@ function App() {
         const parsed = JSON.parse(event.payload);
         switch (parsed.event) {
           case "SYSTEM_READY": setStatus(parsed.data.status); break;
+          case "VAD_TELEMETRY":
+            setAudioLevel(parsed.data.level ?? 0);
+            break;
           case "RECORDING_STATUS":
             setIsRecording(parsed.data.is_recording);
             if (parsed.data.is_recording) {
@@ -690,6 +705,7 @@ function App() {
               className={`record-btn-pill ${isRecording ? "recording" : ""}`}
               onClick={toggleRecording}
               title={isRecording ? "Stop Recording" : "Start Recording"}
+              style={isRecording ? { transform: `scale(${1 + audioLevel * 0.12})`, transition: "transform 80ms ease-out" } : undefined}
             >
               {isRecording ? <span className="stop-square" /> : <span className="record-circle" />}
             </button>


### PR DESCRIPTION
**Context:** The `AudioCaptureStrategy` in `audio_capture.py` captures audio in chunks
but emits no real-time signal. The UI has no feedback that audio is actually arriving.

**Task:** Calculate RMS volume inside the capture loop and emit `VAD_TELEMETRY` events
to React without spamming the Rust console.

### Acceptance Criteria
- [x] Add a `telemetry_callback` parameter to `AudioCaptureStrategy` in `audio_capture.py`.
- [x] Calculate RMS every 5th chunk and trigger the callback with a normalized 0–1 value.
- [x] In `main.py`, pass a callback that emits `{"event": "VAD_TELEMETRY", "data": {"level": 0.62}}` via stdout.
- [x] In `lib.rs`, filter `VAD_TELEMETRY` in the `BufReader` loop — suppress `println!`
      but still forward to React via `app_handle.emit`.
- [x] Level meter bar in the settings popover consumes the same event.
- [x] Add commit: `feat(ai): emit vad telemetry events from audio capture`.

**Context:** The compact widget record button is static. With VAD telemetry available
(Card 7.2), we can give the user organic visual feedback while recording.

**Task:** Bind the record button scale to the incoming `VAD_TELEMETRY` audio level.

### Acceptance Criteria
- [x] Add `VAD_TELEMETRY` case to the `python-event` listener switch in `App.tsx`.
- [x] Store intensity in `audioLevel` state (`useState(0)`).
- [x] Apply `transform: scale(1 + audioLevel * 0.12)` inline on the compact record button.
- [x] Animation is disabled when `isRecording === false` to avoid reacting to ambient noise.
- [x] Add commit: `feat(ui): bind record button pulse to vad telemetry`.

**Depends on:** Card 7.2