### PR TITLE
feat(ui): add language and model dropdowns to settings popover

### DIFF
--- a/src-python/main.py
+++ b/src-python/main.py
@@ -53,6 +53,7 @@ def main():
                     "system_audio": command.get("system_audio", False),
                     "auto_summarize": command.get("auto_summarize", True),
                     "speaker_diarization": command.get("speaker_diarization", False),
+                    "language": command.get("language", "auto"),
                     "llm_provider": command.get("llm_provider", "ollama"),
                     "llm_model": command.get("llm_model", "llama3"),
                     "api_key": command.get("api_key", ""),
@@ -73,7 +74,11 @@ def main():
                 # STEP B: Transcribe audio
                 if transcriber:
                     send_event("PIPELINE_STATUS", {"step": "Transcribing with WhisperX..."})
-                    transcription_result = transcriber.transcribe(saved_file_path)
+                    lang = current_config.get("language", "auto")
+                    transcription_result = transcriber.transcribe(
+                        saved_file_path,
+                        language=None if lang == "auto" else lang
+                    )
                     send_event("TRANSCRIPTION_COMPLETED", {"text": transcription_result})
 
                     # STEP C: Generate Notes — only if auto_summarize is enabled

--- a/src-python/transcription_service.py
+++ b/src-python/transcription_service.py
@@ -52,7 +52,7 @@ class TranscriptionService:
                 print(f"DEBUG: [AI Critical Error] Falha total no carregamento do modelo: {str(fallback_error)}", file=sys.stderr)
                 self.model = None
 
-    def transcribe(self, audio_path: str) -> str:
+    def transcribe(self, audio_path: str, language: str | None = None) -> str:
         if self.model is None:
             return "[Error: WhisperX model not loaded]"
 
@@ -66,7 +66,7 @@ class TranscriptionService:
 
         try:
             audio = whisperx.load_audio(audio_path)
-            result = self.model.transcribe(audio, batch_size=4)
+            result = self.model.transcribe(audio, batch_size=4, language=language)
             segments = result.get("segments", [])
             full_text = " ".join([seg["text"].strip() for seg in segments])
 

--- a/src/App.css
+++ b/src/App.css
@@ -379,6 +379,26 @@ input, select { font-family: inherit; }
   flex-shrink: 0;
 }
 
+/* ── Popover dual-column row ───────────────────────────────── */
+.popover-row-dual {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.popover-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.popover-col .popover-row-label {
+  display: block;
+  margin-bottom: 2px;
+}
+
 /* ── Popover level meter ───────────────────────────────────── */
 .popover-level-meter {
   height: 3px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ interface SettingsPayload {
   modelName: string;
   apiKey: string;
   theme: string;
+  language: string;
   systemAudio: boolean;
   autoSummarize: boolean;
   speakerDiarization: boolean;
@@ -237,6 +238,8 @@ interface AudioDevice {
 function PopoverWindowContent() {
   const [provider, setProvider] = useState("ollama");
   const [modelName, setModelName] = useState("llama3");
+  const [customModel, setCustomModel] = useState("");
+  const [language, setLanguage] = useState("auto");
   const [apiKey, setApiKey] = useState("");
   const [theme, setTheme] = useState("liquid-glass");
   const [devices, setDevices] = useState<AudioDevice[]>([]);
@@ -256,6 +259,8 @@ function PopoverWindowContent() {
         const store = await load("settings.json", { autoSave: false, defaults: {} });
         const sp = await store.get<string>("provider");
         const sm = await store.get<string>("modelName");
+        const scm = await store.get<string>("customModel");
+        const sl = await store.get<string>("language");
         const sk = await store.get<string>("apiKey");
         const st = await store.get<string>("theme");
         const sd = await store.get<number>("selectedDeviceId");
@@ -265,6 +270,8 @@ function PopoverWindowContent() {
         const aot = await store.get<boolean>("alwaysOnTop");
         if (sp) setProvider(sp);
         if (sm) setModelName(sm);
+        if (scm) setCustomModel(scm);
+        if (sl) setLanguage(sl);
         if (sk) setApiKey(sk);
         if (st) setTheme(st);
         if (sd != null) setSelectedDevice(sd);
@@ -323,8 +330,11 @@ function PopoverWindowContent() {
   const handleSave = async () => {
     try {
       const store = await load("settings.json", { autoSave: false, defaults: {} });
+      const effectiveModel = customModel.trim() || modelName;
       await store.set("provider", provider);
-      await store.set("modelName", modelName);
+      await store.set("modelName", effectiveModel);
+      await store.set("customModel", customModel);
+      await store.set("language", language);
       await store.set("apiKey", apiKey);
       await store.set("theme", theme);
       await store.set("systemAudio", systemAudio);
@@ -334,7 +344,7 @@ function PopoverWindowContent() {
       if (selectedDevice !== null) await store.set("selectedDeviceId", selectedDevice);
       await store.save();
       await emit("settings-changed", {
-        provider, modelName, apiKey, theme,
+        provider, modelName: effectiveModel, apiKey, theme, language,
         systemAudio, autoSummarize, speakerDiarization, alwaysOnTop,
       } satisfies SettingsPayload);
       await win.close();
@@ -395,15 +405,76 @@ function PopoverWindowContent() {
         </select>
       </div>
 
-      {/* Model */}
-      <div className="popover-row">
-        <label className="popover-row-label">Model</label>
-        <input
-          className="popover-input"
-          type="text"
-          value={modelName}
-          onChange={(e) => setModelName(e.target.value)}
-        />
+      {/* Model + Language — two columns */}
+      <div className="popover-row-dual">
+        <div className="popover-col">
+          <label className="popover-row-label">Model</label>
+          <select
+            className="popover-select"
+            value={customModel ? "custom" : modelName}
+            onChange={(e) => {
+              if (e.target.value === "custom") {
+                setModelName("custom");
+              } else {
+                setModelName(e.target.value);
+                setCustomModel("");
+              }
+            }}
+          >
+            <optgroup label="Ollama">
+              <option value="llama3">llama3</option>
+              <option value="llama3.1">llama3.1</option>
+              <option value="gemma3">gemma3</option>
+              <option value="mistral">mistral</option>
+              <option value="phi4">phi4</option>
+            </optgroup>
+            <optgroup label="OpenAI">
+              <option value="gpt-4o">gpt-4o</option>
+              <option value="gpt-4o-mini">gpt-4o-mini</option>
+              <option value="gpt-4-turbo">gpt-4-turbo</option>
+            </optgroup>
+            <optgroup label="Anthropic">
+              <option value="claude-sonnet-4-5">claude-sonnet-4-5</option>
+              <option value="claude-haiku-4-5">claude-haiku-4-5</option>
+            </optgroup>
+            <optgroup label="Gemini">
+              <option value="gemini-2.0-flash">gemini-2.0-flash</option>
+              <option value="gemini-1.5-pro">gemini-1.5-pro</option>
+            </optgroup>
+            <option value="custom">Custom…</option>
+          </select>
+          {(modelName === "custom" || customModel) && (
+            <input
+              className="popover-input"
+              type="text"
+              placeholder="model-name"
+              value={customModel}
+              onChange={(e) => setCustomModel(e.target.value)}
+              style={{ marginTop: 5 }}
+            />
+          )}
+        </div>
+
+        <div className="popover-col">
+          <label className="popover-row-label">Language</label>
+          <select
+            className="popover-select"
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+          >
+            <option value="auto">Auto detect</option>
+            <option value="pt">Português</option>
+            <option value="en">English</option>
+            <option value="es">Español</option>
+            <option value="fr">Français</option>
+            <option value="de">Deutsch</option>
+            <option value="it">Italiano</option>
+            <option value="ja">日本語</option>
+            <option value="zh">中文</option>
+            <option value="ko">한국어</option>
+            <option value="ru">Русский</option>
+          </select>
+        </div>
       </div>
 
       {/* API key */}
@@ -569,6 +640,7 @@ function App() {
   const [modelName, setModelName] = useState("llama3");
   const [apiKey, setApiKey] = useState("");
   const [theme, setTheme] = useState("liquid-glass");
+  const [language, setLanguage] = useState("auto");
   const [systemAudio, setSystemAudio] = useState(false);
   const [autoSummarize, setAutoSummarize] = useState(true);
   const [speakerDiarization, setSpeakerDiarization] = useState(false);
@@ -619,11 +691,13 @@ function App() {
   useEffect(() => {
     const unlisten = listen<SettingsPayload>("settings-changed", (event) => {
       const { provider: p, modelName: m, apiKey: k, theme: t,
+              language: l,
               systemAudio: sa, autoSummarize: as_, speakerDiarization: sd, alwaysOnTop: aot } = event.payload;
       setProvider(p);
       setModelName(m);
       setApiKey(k);
       setTheme(t);
+      setLanguage(l);
       setSystemAudio(sa);
       setAutoSummarize(as_);
       setSpeakerDiarization(sd);
@@ -711,6 +785,7 @@ function App() {
           llm_provider: provider,
           llm_model: modelName,
           api_key: apiKey,
+          language,
           system_audio: systemAudio,
           auto_summarize: autoSummarize,
           speaker_diarization: speakerDiarization,


### PR DESCRIPTION
- Replace model text input with grouped dropdown + custom model input
- Add language dropdown with 11 WhisperX-supported locales + auto detect
- Two-column layout for model and language side by side
- Pass language to transcriber; None when auto (WhisperX detects)
- Extend SettingsPayload and sync language state across windows



### Acceptance Criteria
- [x] Model: dropdown with common options (haiku, sonnet, llama3, gpt-4o, whisper…).
      Keep a custom text input for models outside the list.
- [x] Language: dropdown with WhisperX-supported locales (auto, pt, en, es, fr, de…).
- [x] Layout: two equal-width columns side by side (`flex: 1` each) — matching the design.
- [x] Both values saved to `settings.json` and passed in `START_RECORDING`.
- [x] Add commit: `feat(ui): add language and model dropdowns to popover`.