### PR TITLE
81 UI preferences shortcuts buttons in popover footer

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -128,8 +128,8 @@ async fn open_popover_window(app: AppHandle, window: Window) -> Result<(), Strin
     let pos = window.outer_position().map_err(|e| e.to_string())?;
     let size = window.outer_size().map_err(|e| e.to_string())?;
 
-    let popover_w = 284.0_f64;
-    let popover_h = 344.0_f64;
+    let popover_w = 300.0_f64;
+    let popover_h = 480.0_f64;
     let gap = 8.0_f64;
 
     // Right-align with main window; clamp so it does not go off-screen left

--- a/src/App.css
+++ b/src/App.css
@@ -363,20 +363,38 @@ input, select { font-family: inherit; }
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  padding: 14px;
-  /* Remove the absolute-positioning from .compact-popover */
+  padding: 0;
   position: static;
   bottom: unset;
   right: unset;
-  /* Keep border-radius from popover-lg / popover-nb for rounded corners
-     against the transparent OS window shadow on macOS */
 }
 
 .popover-drag-handle {
   height: 20px;
-  margin: -14px -14px 10px -14px; /* bleed to edges */
-  cursor: grab;
   flex-shrink: 0;
+  cursor: grab;
+}
+
+/* Scrollable content area between drag handle and footer */
+.popover-scroll-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 14px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  scrollbar-width: thin;
+}
+
+.popover-lg .popover-scroll-body { scrollbar-color: rgba(255,255,255,0.15) transparent; }
+.popover-nb .popover-scroll-body { scrollbar-color: #d0c8bc transparent; }
+
+/* Footer stays pinned at bottom */
+.popover-footer-bar {
+  flex-shrink: 0;
+  padding: 10px 14px 12px;
+  margin-top: 0;
+  border-top: 1px solid;
 }
 
 /* ── Popover dual-column row ───────────────────────────────── */
@@ -605,19 +623,6 @@ input, select { font-family: inherit; }
   border: none;
   border-radius: 2px;
 }
-
-.popover-footer-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding-top: 10px;
-  margin-top: 6px;
-  border-top: 1px solid;
-}
-
-.popover-lg .popover-footer-bar { border-color: rgba(255,255,255,0.1); }
-.popover-nb .popover-footer-bar { border-color: #d0c8bc; }
 
 .popover-footer-left {
   display: flex;

--- a/src/App.css
+++ b/src/App.css
@@ -569,20 +569,8 @@ input, select { font-family: inherit; }
 .popover-lg .popover-toggle-hint  { color: rgba(255,255,255,0.38); }
 .popover-nb .popover-toggle-hint  { color: #8a8277; }
 
-.popover-footer {
-  display: flex;
-  gap: 6px;
-  padding-top: 10px;
-  margin-top: 6px;
-  border-top: 1px solid;
-}
-
-.popover-lg .popover-footer { border-color: rgba(255,255,255,0.1); }
-.popover-nb .popover-footer { border-color: #d0c8bc; }
-
 .popover-btn {
-  flex: 1;
-  padding: 6px 10px;
+  padding: 6px 14px;
   font-size: 11.5px;
   font-weight: 500;
   border-radius: 7px;
@@ -616,6 +604,172 @@ input, select { font-family: inherit; }
   color: #faf6ec;
   border: none;
   border-radius: 2px;
+}
+
+.popover-footer-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding-top: 10px;
+  margin-top: 6px;
+  border-top: 1px solid;
+}
+
+.popover-lg .popover-footer-bar { border-color: rgba(255,255,255,0.1); }
+.popover-nb .popover-footer-bar { border-color: #d0c8bc; }
+
+.popover-footer-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.popover-text-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 2px;
+  transition: opacity 120ms;
+}
+
+.popover-text-btn:hover { opacity: 0.6; }
+.popover-lg .popover-text-btn { color: rgba(255,255,255,0.55); }
+.popover-nb .popover-text-btn { color: #8a8277; }
+
+.popover-footer-sep {
+  width: 1px;
+  height: 12px;
+  border-radius: 1px;
+}
+
+.popover-lg .popover-footer-sep { background: rgba(255,255,255,0.15); }
+.popover-nb .popover-footer-sep { background: #d0c8bc; }
+
+/* ── Shortcuts modal ───────────────────────────────────────── */
+.shortcuts-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.shortcuts-modal {
+  width: 240px;
+  border-radius: var(--radius, 12px);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+}
+
+.shortcuts-lg {
+  background: rgba(28, 26, 40, 0.97);
+  border: 0.5px solid rgba(255,255,255,0.12);
+  backdrop-filter: blur(20px);
+}
+
+.shortcuts-nb {
+  background: #faf6ec;
+  border: 0.5px solid #d0c8bc;
+}
+
+.shortcuts-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.shortcuts-title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.shortcuts-lg .shortcuts-title { color: rgba(255,255,255,0.5); }
+.shortcuts-nb .shortcuts-title { color: #8a8277; }
+
+.shortcuts-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 11px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  transition: opacity 120ms;
+}
+
+.shortcuts-close:hover { opacity: 0.6; }
+.shortcuts-lg .shortcuts-close { color: rgba(255,255,255,0.5); }
+.shortcuts-nb .shortcuts-close { color: #8a8277; }
+
+.shortcuts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.shortcut-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.shortcut-label {
+  font-size: 12px;
+}
+
+.shortcuts-lg .shortcut-label { color: rgba(255,255,255,0.85); }
+.shortcuts-nb .shortcut-label { color: #1a1814; }
+
+.shortcut-keys {
+  display: flex;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.shortcut-key {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  padding: 2px 5px;
+  border-radius: 4px;
+  font-style: normal;
+}
+
+.shortcuts-lg .shortcut-key {
+  background: rgba(255,255,255,0.08);
+  border: 0.5px solid rgba(255,255,255,0.15);
+  color: rgba(255,255,255,0.8);
+}
+
+.shortcuts-nb .shortcut-key {
+  background: #f0ece4;
+  border: 0.5px solid #d0c8bc;
+  color: #1a1814;
+}
+
+.shortcuts-note {
+  font-size: 10.5px;
+  line-height: 1.5;
+  padding-top: 6px;
+  border-top: 0.5px solid;
+}
+
+.shortcuts-lg .shortcuts-note {
+  color: rgba(255,255,255,0.3);
+  border-color: rgba(255,255,255,0.08);
+}
+
+.shortcuts-nb .shortcuts-note {
+  color: #8a8277;
+  border-color: #d0c8bc;
 }
 
 /* ── Expanded layout ───────────────────────────────────────── */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -397,12 +397,13 @@ function PopoverWindowContent() {
   return (
     <div
       className={`popover-window ${isLG ? "popover-lg" : "popover-nb"}`}
-      data-tauri-drag-region
     >
-      {/* Drag handle strip */}
+      {/* Drag handle — full width, outside scroll */}
       <div className="popover-drag-handle" data-tauri-drag-region />
 
-      <div className="popover-label">SETTINGS</div>
+      {/* Scrollable content */}
+      <div className="popover-scroll-body">
+        <div className="popover-label">SETTINGS</div>
 
       {/* Input device picker */}
       <div className="popover-row">
@@ -574,7 +575,9 @@ function PopoverWindowContent() {
         </div>
       </div>
 
-      {/* Footer — Preferences · divider · Shortcuts · Save */}
+      </div>{/* end popover-scroll-body */}
+
+      {/* Footer — pinned at bottom */}
       <div className="popover-footer-bar">
         <div className="popover-footer-left">
           <button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -232,6 +232,46 @@ interface AudioDevice {
   type: "mic" | "loopback";
 }
 
+// ── Shortcuts Modal ───────────────────────────────────────────
+const SHORTCUTS = [
+  { keys: ["⌘", "⇧", "R"],  win: ["Ctrl", "⇧", "R"],  label: "Toggle recording" },
+  { keys: ["⌘", "⇧", "P"],  win: ["Ctrl", "⇧", "P"],  label: "Pause / Resume" },
+  { keys: ["⌘", "⇧", "E"],  win: ["Ctrl", "⇧", "E"],  label: "Expand / Collapse" },
+  { keys: ["⌘", "⇧", ","],  win: ["Ctrl", "⇧", ","],  label: "Open settings" },
+];
+
+function ShortcutsModal({ onClose, isLG }: { onClose: () => void; isLG: boolean }) {
+  const isMac = navigator.platform.toLowerCase().includes("mac");
+  return (
+    <div className="shortcuts-overlay" onClick={onClose}>
+      <div
+        className={`shortcuts-modal ${isLG ? "shortcuts-lg" : "shortcuts-nb"}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="shortcuts-header">
+          <span className="shortcuts-title">Keyboard Shortcuts</span>
+          <button className="shortcuts-close" onClick={onClose}>✕</button>
+        </div>
+        <div className="shortcuts-list">
+          {SHORTCUTS.map((s, i) => (
+            <div key={i} className="shortcut-row">
+              <span className="shortcut-label">{s.label}</span>
+              <span className="shortcut-keys">
+                {(isMac ? s.keys : s.win).map((k, j) => (
+                  <kbd key={j} className="shortcut-key">{k}</kbd>
+                ))}
+              </span>
+            </div>
+          ))}
+        </div>
+        <div className="shortcuts-note">
+          Global shortcuts work even when the app is not in focus.
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ── Popover Window Content ────────────────────────────────────
 // Rendered when window label is "popover". Self-contained: loads settings
 // from store, emits "settings-changed" on save, closes itself on blur.
@@ -249,6 +289,7 @@ function PopoverWindowContent() {
   const [autoSummarize, setAutoSummarize] = useState(true);
   const [speakerDiarization, setSpeakerDiarization] = useState(false);
   const [alwaysOnTop, setAlwaysOnTop] = useState(true);
+  const [showShortcuts, setShowShortcuts] = useState(false);
   const isLG = theme !== "minimalist-notebook";
   const win = getCurrentWindow();
 
@@ -533,11 +574,30 @@ function PopoverWindowContent() {
         </div>
       </div>
 
-      {/* Footer */}
-      <div className="popover-footer">
-        <button className="popover-btn secondary" onClick={() => win.close()}>Cancel</button>
+      {/* Footer — Preferences · divider · Shortcuts · Save */}
+      <div className="popover-footer-bar">
+        <div className="popover-footer-left">
+          <button
+            className="popover-text-btn"
+            onClick={async () => {
+              await handleSave();
+              await invoke("set_expanded_mode");
+            }}
+          >
+            Preferences…
+          </button>
+          <span className="popover-footer-sep" />
+          <button
+            className="popover-text-btn"
+            onClick={() => setShowShortcuts(true)}
+          >
+            Shortcuts
+          </button>
+        </div>
         <button className="popover-btn primary" onClick={handleSave}>Save</button>
       </div>
+
+      {showShortcuts && <ShortcutsModal onClose={() => setShowShortcuts(false)} isLG={isLG} />}
     </div>
   );
 }


### PR DESCRIPTION
**Context:** The design specifies a footer row with two action buttons below the toggles.

**Task:** Implement the popover footer with Preferences and Shortcuts actions.

### Acceptance Criteria
- [x] **Preferences…** — closes the popover and opens the expanded window with the
      Settings tab active.
- [x] **Shortcuts** — opens a modal listing all available global keyboard shortcuts.
- [x] Footer layout: Preferences left · divider · Shortcuts right — matching the design.
- [x] Add commit: `feat(ui): add preferences and shortcuts buttons to popover footer`.