### PR TITLE
feat(ui): add participant avatars and tags to expanded header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -970,6 +970,191 @@ input, select { font-family: inherit; }
 }
 
 /* Meeting header */
+/* ── Meeting header extras ─────────────────────────────────── */
+.meeting-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.participant-avatars {
+  display: flex;
+  flex-direction: row-reverse;
+  flex-shrink: 0;
+}
+
+.participant-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 8px;
+  font-weight: 700;
+  color: #fff;
+  border: 2px solid var(--bg-app, #1a1a2e);
+  margin-left: -6px;
+  letter-spacing: 0.02em;
+}
+
+.participant-avatar-overflow {
+  background: var(--bg-hover);
+  color: var(--text-dim);
+  font-size: 8px;
+}
+
+/* ── Tag row ───────────────────────────────────────────────── */
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  margin-top: 6px;
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 2px 7px 2px 8px;
+  border-radius: 99px;
+}
+
+[data-theme="liquid-glass"] .tag-chip {
+  background: rgba(255,255,255,0.08);
+  color: rgba(255,255,255,0.65);
+  border: 0.5px solid rgba(255,255,255,0.14);
+}
+
+[data-theme="minimalist-notebook"] .tag-chip {
+  background: #f0ece4;
+  color: #5a5248;
+  border: 0.5px solid #d0c8bc;
+}
+
+.tag-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  padding: 0;
+  opacity: 0.5;
+  transition: opacity 120ms;
+}
+
+.tag-remove:hover { opacity: 1; }
+
+[data-theme="liquid-glass"] .tag-remove { color: rgba(255,255,255,0.8); }
+[data-theme="minimalist-notebook"] .tag-remove { color: #5a5248; }
+
+.tag-add-btn {
+  background: none;
+  border: 0.5px dashed;
+  border-radius: 99px;
+  font-size: 10px;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: opacity 120ms;
+}
+
+.tag-add-btn:hover { opacity: 0.7; }
+
+[data-theme="liquid-glass"] .tag-add-btn {
+  border-color: rgba(255,255,255,0.2);
+  color: rgba(255,255,255,0.4);
+}
+
+[data-theme="minimalist-notebook"] .tag-add-btn {
+  border-color: #c0b8ae;
+  color: #8a8277;
+}
+
+.tag-input {
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: 99px;
+  outline: none;
+  width: 90px;
+}
+
+[data-theme="liquid-glass"] .tag-input {
+  background: rgba(255,255,255,0.08);
+  border: 0.5px solid rgba(255,255,255,0.25);
+  color: rgba(255,255,255,0.9);
+}
+
+[data-theme="minimalist-notebook"] .tag-input {
+  background: #fff;
+  border: 0.5px solid #a0988e;
+  color: #2a2520;
+}
+
+/* ── Diarized transcript ───────────────────────────────────── */
+.transcript-diarized {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-bottom: 8px;
+}
+
+.transcript-line {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.transcript-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 600;
+  color: #fff;
+  flex-shrink: 0;
+  margin-top: 2px;
+  letter-spacing: 0.02em;
+}
+
+.transcript-line-body { flex: 1; min-width: 0; }
+
+.transcript-line-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 3px;
+}
+
+.transcript-speaker {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.transcript-timestamp {
+  font-size: 10px;
+  font-family: var(--font-mono, monospace);
+}
+
+[data-theme="liquid-glass"] .transcript-timestamp { color: rgba(255,255,255,0.3); }
+[data-theme="minimalist-notebook"] .transcript-timestamp { color: #b0a898; }
+
+.transcript-line-text {
+  font-size: 13px;
+  line-height: 1.6;
+  margin: 0;
+}
+
+[data-theme="liquid-glass"] .transcript-line-text { color: rgba(255,255,255,0.82); }
+[data-theme="minimalist-notebook"] .transcript-line-text { color: #2a2520; }
+
 .meeting-header {
   display: flex;
   align-items: center;
@@ -1138,67 +1323,6 @@ input, select { font-family: inherit; }
   );
   padding-left: 72px;
 }
-
-/* ── Diarized transcript ───────────────────────────────────── */
-.transcript-diarized {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  padding-bottom: 8px;
-}
-
-.transcript-line {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-}
-
-.transcript-avatar {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 10px;
-  font-weight: 600;
-  color: #fff;
-  flex-shrink: 0;
-  margin-top: 2px;
-  letter-spacing: 0.02em;
-}
-
-.transcript-line-body { flex: 1; min-width: 0; }
-
-.transcript-line-meta {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 3px;
-}
-
-.transcript-speaker {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-.transcript-timestamp {
-  font-size: 10px;
-  font-family: var(--font-mono, monospace);
-}
-
-[data-theme="liquid-glass"] .transcript-timestamp { color: rgba(255,255,255,0.3); }
-[data-theme="minimalist-notebook"] .transcript-timestamp { color: #b0a898; }
-
-.transcript-line-text {
-  font-size: 13px;
-  line-height: 1.6;
-  margin: 0;
-}
-
-[data-theme="liquid-glass"] .transcript-line-text { color: rgba(255,255,255,0.82); }
-[data-theme="minimalist-notebook"] .transcript-line-text { color: #2a2520; }
 
 /* Transcript */
 .transcript-text {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ interface DiarizedSegment {
   text: string;
 }
 
-// Deterministic color from speaker name — same speaker always gets same color
+// ── Speaker color helpers ──────────────────────────────────────
 const SPEAKER_PALETTE = [
   "#6C8EBF", "#82B366", "#D6A520", "#AE4132",
   "#7B5EA7", "#2D9B8A", "#C0714F", "#4A7C9E",
@@ -57,13 +57,12 @@ function formatTimestamp(seconds: number): string {
 }
 
 // ── TranscriptLine ─────────────────────────────────────────────
-function TranscriptLine({ seg, isLG }: { seg: DiarizedSegment; isLG: boolean }) {
+function TranscriptLine({ seg }: { seg: DiarizedSegment }) {
   const color = speakerColor(seg.speaker);
-  const initials = speakerInitials(seg.speaker);
   return (
     <div className="transcript-line">
       <div className="transcript-avatar" style={{ background: color }} title={seg.speaker}>
-        {initials}
+        {speakerInitials(seg.speaker)}
       </div>
       <div className="transcript-line-body">
         <div className="transcript-line-meta">
@@ -72,6 +71,77 @@ function TranscriptLine({ seg, isLG }: { seg: DiarizedSegment; isLG: boolean }) 
         </div>
         <p className="transcript-line-text">{seg.text}</p>
       </div>
+    </div>
+  );
+}
+
+// ── ParticipantAvatars ─────────────────────────────────────────
+function ParticipantAvatars({ speakers }: { speakers: string[] }) {
+  if (!speakers.length) return null;
+  const visible = speakers.slice(0, 5);
+  const overflow = speakers.length - visible.length;
+  return (
+    <div className="participant-avatars">
+      {visible.map((s, i) => (
+        <div
+          key={s}
+          className="participant-avatar"
+          style={{ background: speakerColor(s), zIndex: visible.length - i }}
+          title={s}
+        >
+          {speakerInitials(s)}
+        </div>
+      ))}
+      {overflow > 0 && (
+        <div className="participant-avatar participant-avatar-overflow">
+          +{overflow}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── TagRow ─────────────────────────────────────────────────────
+function TagRow({
+  tags, onAdd, onRemove,
+}: {
+  tags: string[];
+  onAdd: (t: string) => void;
+  onRemove: (t: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [input, setInput] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const commit = () => {
+    const val = input.trim().toLowerCase().replace(/\s+/g, "-");
+    if (val && !tags.includes(val)) onAdd(val);
+    setInput("");
+    setEditing(false);
+  };
+
+  return (
+    <div className="tag-row">
+      {tags.map((t) => (
+        <span key={t} className="tag-chip">
+          {t}
+          <button className="tag-remove" onClick={() => onRemove(t)}>×</button>
+        </span>
+      ))}
+      {editing ? (
+        <input
+          ref={inputRef}
+          className="tag-input"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") commit(); if (e.key === "Escape") setEditing(false); }}
+          onBlur={commit}
+          placeholder="add tag…"
+          autoFocus
+        />
+      ) : (
+        <button className="tag-add-btn" onClick={() => setEditing(true)}>+ tag</button>
+      )}
     </div>
   );
 }
@@ -756,6 +826,7 @@ function App() {
   const [status, setStatus] = useState("Initializing system…");
   const [transcription, setTranscription] = useState("");
   const [diarizedSegments, setDiarizedSegments] = useState<DiarizedSegment[] | null>(null);
+  const [meetingTags, setMeetingTags] = useState<string[]>([]);
   const [notes, setNotes] = useState("");
   const [isExpanded, setIsExpanded] = useState(false);
   const [recordingSeconds, setRecordingSeconds] = useState(0);
@@ -791,6 +862,12 @@ function App() {
 
   const actionItems = useMemo(() => (notes ? parseActionItems(notes) : []), [notes]);
   const tldr = useMemo(() => (notes ? parseTldr(notes) : null), [notes]);
+
+  const participants = useMemo(() => {
+    if (!diarizedSegments) return [];
+    return [...new Set(diarizedSegments.map((s) => s.speaker))];
+  }, [diarizedSegments]);
+
   const filteredTranscript = useMemo(() => {
     if (!transcription || !search.trim()) return transcription;
     return transcription
@@ -894,7 +971,7 @@ function App() {
             setIsRecording(parsed.data.is_recording);
             if (parsed.data.is_recording) {
               setTranscription(""); setNotes("");
-              setDiarizedSegments(null);
+              setDiarizedSegments(null); setMeetingTags([]);
               setSelectedMeetingId(null); setActiveTab("transcript");
             }
             break;
@@ -1079,14 +1156,26 @@ function App() {
         <main className="main-content">
           <div className="meeting-header">
             <div className="meeting-header-left">
-              <div className="meeting-title">
-                {selectedMeetingId
-                  ? meetingsHistory.find((m) => m.id === selectedMeetingId)?.title ?? "Meeting"
-                  : "Current Session"}
+              <div className="meeting-title-row">
+                <div className="meeting-title">
+                  {selectedMeetingId
+                    ? meetingsHistory.find((m) => m.id === selectedMeetingId)?.title ?? "Meeting"
+                    : "Current Session"}
+                </div>
+                {participants.length > 0 && (
+                  <ParticipantAvatars speakers={participants} />
+                )}
               </div>
               <div className="meeting-meta">
                 {isRecording ? `Recording · ${formatDuration(recordingSeconds)}` : status}
               </div>
+              {(meetingTags.length > 0 || !selectedMeetingId) && (
+                <TagRow
+                  tags={meetingTags}
+                  onAdd={(t) => setMeetingTags((prev) => [...prev, t])}
+                  onRemove={(t) => setMeetingTags((prev) => prev.filter((x) => x !== t))}
+                />
+              )}
             </div>
             <div className="meeting-header-right">
               {isRecording && <Waveform width={60} height={14} color={waveColor} active bars={14} />}
@@ -1123,7 +1212,7 @@ function App() {
                 {filteredSegments ? (
                   <div className="transcript-diarized">
                     {filteredSegments.map((seg, i) => (
-                      <TranscriptLine key={i} seg={seg} isLG={isLG} />
+                      <TranscriptLine key={i} seg={seg} />
                     ))}
                   </div>
                 ) : filteredTranscript ? (


### PR DESCRIPTION
- Add ParticipantAvatars component with overlapping circles (max 5 + overflow)
- Add TagRow component with inline add input and remove button
- Derive unique participants from diarizedSegments via useMemo
- Add meetingTags state, reset on new recording
- Tags normalize to lowercase-hyphenated on commit
- Add TranscriptLine, filteredSegments, and diarized transcript rendering