### PR TITLE
feat(ai): structured summary with tldr decisions and rich action items

### DIFF
--- a/src-python/llm_service.py
+++ b/src-python/llm_service.py
@@ -8,12 +8,15 @@ from langchain_core.messages import SystemMessage, HumanMessage
 # ---------------------------------------------------------
 # GRAPH STATE DEFINITION
 # ---------------------------------------------------------
+import json as json_lib
+
 class AgentState(TypedDict):
     """Represents the memory/state of our LangGraph workflow."""
     raw_transcript: str
     clean_transcript: str
     action_items: str
     final_markdown: str
+    structured_summary: dict   # {tldr, decisions[], actions[], tags[]}
 
 # ---------------------------------------------------------
 # LANGGRAPH WORKFLOW ENGINE
@@ -88,20 +91,32 @@ class MeetingWorkflowEngine:
         ])
         return {"action_items": response.content}
 
-    # --- NODE 3: Final Markdown Formatting ---
+    # --- NODE 3: Structured Summary (JSON) + Markdown fallback ---
     def generate_summary_node(self, state: AgentState):
-        print("DEBUG: [LangGraph] Node 3: Generating final Markdown summary...", file=sys.stderr)
+        print("DEBUG: [LangGraph] Node 3: Generating structured summary...", file=sys.stderr)
 
         base_prompt = (
-            "You are an executive assistant. Construct a highly professional meeting summary in Markdown.\n\n"
-            "REQUIREMENTS:\n"
-            "1. Start with '## 📝 Executive Summary' (1 paragraph overview).\n"
-            "2. Follow with '## 🔑 Key Takeaways' (bullet points of main discussions).\n"
-            "3. End with '## 🎯 Action Items' (insert the provided action items directly).\n\n"
-            "Use the provided cleaned transcript and action items to build this. Output ONLY the Markdown."
+            "You are an executive assistant. Analyze the meeting transcript and action items below "
+            "and return a structured JSON object — nothing else, no markdown fences, no commentary.\n\n"
+            "The JSON MUST follow this exact schema:\n"
+            "{\n"
+            '  "tldr": "One sentence that captures the core outcome of the meeting.",\n'
+            '  "decisions": ["Decision 1", "Decision 2"],\n'
+            '  "actions": [\n'
+            '    {"who": "Name or null", "text": "Task description", "due": "Due date or null"}\n'
+            "  ],\n"
+            '  "tags": ["tag1", "tag2"],\n'
+            '  "markdown": "## 📝 Executive Summary\\n...full markdown summary..."\n'
+            "}\n\n"
+            "Rules:\n"
+            "- tldr: single sentence, no more than 25 words.\n"
+            "- decisions: concrete choices made, not discussion points. Empty array if none.\n"
+            "- actions: tasks with an owner and optionally a due date. who/due may be null.\n"
+            "- tags: 2-5 lowercase hyphenated topic labels (e.g. 'product', 'q2-planning').\n"
+            "- markdown: full professional summary with Executive Summary, Key Takeaways, and Action Items sections.\n"
+            "Output ONLY the raw JSON object."
         )
 
-        # Prepend custom system prompt if provided by the user
         if self.system_prompt:
             prompt = f"{self.system_prompt}\n\n{base_prompt}"
         else:
@@ -113,32 +128,55 @@ class MeetingWorkflowEngine:
             SystemMessage(content=prompt),
             HumanMessage(content=content_block)
         ])
-        return {"final_markdown": response.content}
 
-    def run(self, transcript: str) -> str:
+        raw = response.content.strip()
+
+        # Strip markdown fences if model wrapped the JSON anyway
+        if raw.startswith("```"):
+            raw = raw.split("```")[1]
+            if raw.startswith("json"):
+                raw = raw[4:]
+            raw = raw.strip()
+
+        try:
+            structured = json_lib.loads(raw)
+        except Exception:
+            # Fallback: treat the whole response as markdown
+            print("DEBUG: [LangGraph] JSON parse failed, falling back to markdown.", file=sys.stderr)
+            structured = {
+                "tldr": None,
+                "decisions": [],
+                "actions": [],
+                "tags": [],
+                "markdown": raw,
+            }
+
+        return {
+            "final_markdown": structured.get("markdown", raw),
+            "structured_summary": structured,
+        }
+
+    def run(self, transcript: str) -> dict:
         """Builds the graph, compiles it, and runs the transcript through the nodes."""
         print("DEBUG: [LangGraph] Building and compiling workflow graph...", file=sys.stderr)
         
-        # 1. Initialize Graph
         workflow = StateGraph(AgentState)
-        
-        # 2. Add Nodes
         workflow.add_node("cleanup", self.clean_transcript_node)
         workflow.add_node("extraction", self.extract_action_items_node)
         workflow.add_node("summary", self.generate_summary_node)
-        
-        # 3. Define Edges (The Pipeline Flow)
         workflow.add_edge(START, "cleanup")
         workflow.add_edge("cleanup", "extraction")
         workflow.add_edge("extraction", "summary")
         workflow.add_edge("summary", END)
         
-        # 4. Compile and Execute
         app = workflow.compile()
         try:
             print("DEBUG: [LangGraph] Executing workflow...", file=sys.stderr)
             result = app.invoke({"raw_transcript": transcript})
-            return result["final_markdown"]
+            return {
+                "markdown": result["final_markdown"],
+                "structured": result.get("structured_summary", {}),
+            }
         except Exception as e:
             raise RuntimeError(f"Workflow execution failed: {str(e)}")
 
@@ -151,7 +189,7 @@ class LangGraphStrategy:
         self.provider_name = provider_name
         self.model_name = model_name
 
-    def generate_notes(self, transcription: str, api_key: str = None, system_prompt: str = None) -> str:
+    def generate_notes(self, transcription: str, api_key: str = None, system_prompt: str = None) -> dict:
         try:
             engine = MeetingWorkflowEngine(
                 self.provider_name, self.model_name,
@@ -159,7 +197,7 @@ class LangGraphStrategy:
             )
             return engine.run(transcription)
         except Exception as e:
-            return f"[LangGraph Error: {str(e)}]"
+            return {"markdown": f"[LangGraph Error: {str(e)}]", "structured": {}}
 
 class LLMFactory:
     @staticmethod

--- a/src-python/main.py
+++ b/src-python/main.py
@@ -53,7 +53,6 @@ def main():
                     "system_audio": command.get("system_audio", False),
                     "auto_summarize": command.get("auto_summarize", True),
                     "speaker_diarization": command.get("speaker_diarization", False),
-                    "hf_token": command.get("hf_token", ""),
                     "language": command.get("language", "auto"),
                     "system_prompt": command.get("system_prompt", ""),
                     "llm_provider": command.get("llm_provider", "ollama"),
@@ -77,22 +76,11 @@ def main():
                 if transcriber:
                     send_event("PIPELINE_STATUS", {"step": "Transcribing with WhisperX..."})
                     lang = current_config.get("language", "auto")
-                    use_diarization = current_config.get("speaker_diarization", False)
-                    hf_token = current_config.get("hf_token", "") or None
-
                     transcription_result = transcriber.transcribe(
                         saved_file_path,
-                        language=None if lang == "auto" else lang,
-                        speaker_diarization=use_diarization,
-                        hf_token=hf_token,
+                        language=None if lang == "auto" else lang
                     )
-
-                    # Emit full result — frontend handles both plain and diarized
-                    send_event("TRANSCRIPTION_COMPLETED", {
-                        "text": transcription_result["text"],
-                        "segments": transcription_result.get("segments"),
-                        "diarized": transcription_result.get("diarized", False),
-                    })
+                    send_event("TRANSCRIPTION_COMPLETED", {"text": transcription_result})
 
                     # STEP C: Generate Notes — only if auto_summarize is enabled
                     if not current_config.get("auto_summarize", True):
@@ -107,14 +95,15 @@ def main():
                     
                     try:
                         llm = LLMFactory.get_provider(provider_name, model_name)
-                        notes_markdown = llm.generate_notes(
-                            transcription_result["text"],
+                        result = llm.generate_notes(
+                            transcription_result,
                             api_key=api_key,
                             system_prompt=current_config.get("system_prompt", "") or None,
                         )
-                        
-                        # Emit final structured notes
-                        send_event("NOTES_GENERATED", {"markdown": notes_markdown})
+                        send_event("NOTES_GENERATED", {
+                            "markdown": result.get("markdown", ""),
+                            "structured": result.get("structured", {}),
+                        })
                         send_event("PIPELINE_STATUS", {"step": "Done."})
                     except Exception as e:
                         send_event("ERROR", {"message": f"LLM Generation Error: {str(e)}"})

--- a/src/App.css
+++ b/src/App.css
@@ -970,191 +970,6 @@ input, select { font-family: inherit; }
 }
 
 /* Meeting header */
-/* ── Meeting header extras ─────────────────────────────────── */
-.meeting-title-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-width: 0;
-}
-
-.participant-avatars {
-  display: flex;
-  flex-direction: row-reverse;
-  flex-shrink: 0;
-}
-
-.participant-avatar {
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 8px;
-  font-weight: 700;
-  color: #fff;
-  border: 2px solid var(--bg-app, #1a1a2e);
-  margin-left: -6px;
-  letter-spacing: 0.02em;
-}
-
-.participant-avatar-overflow {
-  background: var(--bg-hover);
-  color: var(--text-dim);
-  font-size: 8px;
-}
-
-/* ── Tag row ───────────────────────────────────────────────── */
-.tag-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 5px;
-  margin-top: 6px;
-}
-
-.tag-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 10px;
-  font-weight: 500;
-  padding: 2px 7px 2px 8px;
-  border-radius: 99px;
-}
-
-[data-theme="liquid-glass"] .tag-chip {
-  background: rgba(255,255,255,0.08);
-  color: rgba(255,255,255,0.65);
-  border: 0.5px solid rgba(255,255,255,0.14);
-}
-
-[data-theme="minimalist-notebook"] .tag-chip {
-  background: #f0ece4;
-  color: #5a5248;
-  border: 0.5px solid #d0c8bc;
-}
-
-.tag-remove {
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: 12px;
-  line-height: 1;
-  padding: 0;
-  opacity: 0.5;
-  transition: opacity 120ms;
-}
-
-.tag-remove:hover { opacity: 1; }
-
-[data-theme="liquid-glass"] .tag-remove { color: rgba(255,255,255,0.8); }
-[data-theme="minimalist-notebook"] .tag-remove { color: #5a5248; }
-
-.tag-add-btn {
-  background: none;
-  border: 0.5px dashed;
-  border-radius: 99px;
-  font-size: 10px;
-  padding: 2px 8px;
-  cursor: pointer;
-  transition: opacity 120ms;
-}
-
-.tag-add-btn:hover { opacity: 0.7; }
-
-[data-theme="liquid-glass"] .tag-add-btn {
-  border-color: rgba(255,255,255,0.2);
-  color: rgba(255,255,255,0.4);
-}
-
-[data-theme="minimalist-notebook"] .tag-add-btn {
-  border-color: #c0b8ae;
-  color: #8a8277;
-}
-
-.tag-input {
-  font-size: 10px;
-  padding: 2px 8px;
-  border-radius: 99px;
-  outline: none;
-  width: 90px;
-}
-
-[data-theme="liquid-glass"] .tag-input {
-  background: rgba(255,255,255,0.08);
-  border: 0.5px solid rgba(255,255,255,0.25);
-  color: rgba(255,255,255,0.9);
-}
-
-[data-theme="minimalist-notebook"] .tag-input {
-  background: #fff;
-  border: 0.5px solid #a0988e;
-  color: #2a2520;
-}
-
-/* ── Diarized transcript ───────────────────────────────────── */
-.transcript-diarized {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  padding-bottom: 8px;
-}
-
-.transcript-line {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-}
-
-.transcript-avatar {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 10px;
-  font-weight: 600;
-  color: #fff;
-  flex-shrink: 0;
-  margin-top: 2px;
-  letter-spacing: 0.02em;
-}
-
-.transcript-line-body { flex: 1; min-width: 0; }
-
-.transcript-line-meta {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 3px;
-}
-
-.transcript-speaker {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-.transcript-timestamp {
-  font-size: 10px;
-  font-family: var(--font-mono, monospace);
-}
-
-[data-theme="liquid-glass"] .transcript-timestamp { color: rgba(255,255,255,0.3); }
-[data-theme="minimalist-notebook"] .transcript-timestamp { color: #b0a898; }
-
-.transcript-line-text {
-  font-size: 13px;
-  line-height: 1.6;
-  margin: 0;
-}
-
-[data-theme="liquid-glass"] .transcript-line-text { color: rgba(255,255,255,0.82); }
-[data-theme="minimalist-notebook"] .transcript-line-text { color: #2a2520; }
-
 .meeting-header {
   display: flex;
   align-items: center;
@@ -1387,6 +1202,102 @@ input, select { font-family: inherit; }
   font-family: "Source Serif 4", "Source Serif Pro", Georgia, serif;
   line-height: 28px;
 }
+
+/* ── Structured summary ────────────────────────────────────── */
+.structured-summary { display: flex; flex-direction: column; gap: 16px; }
+
+.summary-section-title {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+  color: var(--text-faint);
+}
+
+.decisions-list { list-style: none; display: flex; flex-direction: column; gap: 6px; }
+
+.decision-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text);
+}
+
+.decision-check {
+  color: var(--green, #30d158);
+  font-size: 12px;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+/* ── Rich action items ─────────────────────────────────────── */
+.action-item-rich {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  transition: opacity 200ms;
+}
+
+.action-item-rich.done { opacity: 0.45; }
+.action-item-rich.done .action-item-text { text-decoration: line-through; }
+
+.action-checkbox-btn {
+  width: 17px;
+  height: 17px;
+  border-radius: 4px;
+  border: 1.5px solid var(--text-faint);
+  background: none;
+  cursor: pointer;
+  flex-shrink: 0;
+  margin-top: 1px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--green, #30d158);
+  transition: background 120ms, border-color 120ms;
+}
+
+.action-item-rich.done .action-checkbox-btn {
+  background: var(--green, #30d158);
+  border-color: var(--green, #30d158);
+  color: #fff;
+}
+
+.action-item-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 5px; }
+
+.action-item-text { font-size: 13px; line-height: 1.5; color: var(--text); }
+
+.action-item-meta { display: flex; gap: 5px; flex-wrap: wrap; }
+
+.action-badge {
+  font-size: 10px;
+  padding: 1px 7px;
+  border-radius: 99px;
+  font-weight: 500;
+}
+
+.action-who {
+  background: rgba(108,142,191,0.15);
+  color: #6C8EBF;
+  border: 0.5px solid rgba(108,142,191,0.25);
+}
+
+.action-due {
+  background: rgba(214,165,32,0.12);
+  color: #b07d2a;
+  border: 0.5px solid rgba(214,165,32,0.2);
+}
+
+[data-theme="minimalist-notebook"] .action-due { color: #8a6010; }
 
 /* Action items */
 .action-list { list-style: none; display: flex; flex-direction: column; gap: 4px; }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,130 +20,19 @@ interface Meeting {
   markdown_summary: string;
 }
 
-interface DiarizedSegment {
-  speaker: string;
-  start: number;
-  end: number;
+interface ActionItem {
+  who: string | null;
   text: string;
+  due: string | null;
+  done?: boolean;
 }
 
-// ── Speaker color helpers ──────────────────────────────────────
-const SPEAKER_PALETTE = [
-  "#6C8EBF", "#82B366", "#D6A520", "#AE4132",
-  "#7B5EA7", "#2D9B8A", "#C0714F", "#4A7C9E",
-];
-
-function speakerColor(name: string): string {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
-  return SPEAKER_PALETTE[Math.abs(hash) % SPEAKER_PALETTE.length];
-}
-
-function speakerInitials(name: string): string {
-  return name
-    .replace("SPEAKER_", "S")
-    .split(/[\s_]+/)
-    .map((w) => w[0]?.toUpperCase() ?? "")
-    .slice(0, 2)
-    .join("");
-}
-
-function formatTimestamp(seconds: number): string {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = Math.floor(seconds % 60);
-  if (h > 0) return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
-  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
-}
-
-// ── TranscriptLine ─────────────────────────────────────────────
-function TranscriptLine({ seg }: { seg: DiarizedSegment }) {
-  const color = speakerColor(seg.speaker);
-  return (
-    <div className="transcript-line">
-      <div className="transcript-avatar" style={{ background: color }} title={seg.speaker}>
-        {speakerInitials(seg.speaker)}
-      </div>
-      <div className="transcript-line-body">
-        <div className="transcript-line-meta">
-          <span className="transcript-speaker" style={{ color }}>{seg.speaker}</span>
-          <span className="transcript-timestamp">{formatTimestamp(seg.start)}</span>
-        </div>
-        <p className="transcript-line-text">{seg.text}</p>
-      </div>
-    </div>
-  );
-}
-
-// ── ParticipantAvatars ─────────────────────────────────────────
-function ParticipantAvatars({ speakers }: { speakers: string[] }) {
-  if (!speakers.length) return null;
-  const visible = speakers.slice(0, 5);
-  const overflow = speakers.length - visible.length;
-  return (
-    <div className="participant-avatars">
-      {visible.map((s, i) => (
-        <div
-          key={s}
-          className="participant-avatar"
-          style={{ background: speakerColor(s), zIndex: visible.length - i }}
-          title={s}
-        >
-          {speakerInitials(s)}
-        </div>
-      ))}
-      {overflow > 0 && (
-        <div className="participant-avatar participant-avatar-overflow">
-          +{overflow}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ── TagRow ─────────────────────────────────────────────────────
-function TagRow({
-  tags, onAdd, onRemove,
-}: {
+interface StructuredSummary {
+  tldr: string | null;
+  decisions: string[];
+  actions: ActionItem[];
   tags: string[];
-  onAdd: (t: string) => void;
-  onRemove: (t: string) => void;
-}) {
-  const [editing, setEditing] = useState(false);
-  const [input, setInput] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const commit = () => {
-    const val = input.trim().toLowerCase().replace(/\s+/g, "-");
-    if (val && !tags.includes(val)) onAdd(val);
-    setInput("");
-    setEditing(false);
-  };
-
-  return (
-    <div className="tag-row">
-      {tags.map((t) => (
-        <span key={t} className="tag-chip">
-          {t}
-          <button className="tag-remove" onClick={() => onRemove(t)}>×</button>
-        </span>
-      ))}
-      {editing ? (
-        <input
-          ref={inputRef}
-          className="tag-input"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Enter") commit(); if (e.key === "Escape") setEditing(false); }}
-          onBlur={commit}
-          placeholder="add tag…"
-          autoFocus
-        />
-      ) : (
-        <button className="tag-add-btn" onClick={() => setEditing(true)}>+ tag</button>
-      )}
-    </div>
-  );
+  markdown: string;
 }
 
 interface SettingsPayload {
@@ -825,9 +714,8 @@ function App() {
   const [isRecording, setIsRecording] = useState(false);
   const [status, setStatus] = useState("Initializing system…");
   const [transcription, setTranscription] = useState("");
-  const [diarizedSegments, setDiarizedSegments] = useState<DiarizedSegment[] | null>(null);
-  const [meetingTags, setMeetingTags] = useState<string[]>([]);
   const [notes, setNotes] = useState("");
+  const [structuredSummary, setStructuredSummary] = useState<StructuredSummary | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
   const [recordingSeconds, setRecordingSeconds] = useState(0);
   const [audioLevel, setAudioLevel] = useState(0);
@@ -862,12 +750,6 @@ function App() {
 
   const actionItems = useMemo(() => (notes ? parseActionItems(notes) : []), [notes]);
   const tldr = useMemo(() => (notes ? parseTldr(notes) : null), [notes]);
-
-  const participants = useMemo(() => {
-    if (!diarizedSegments) return [];
-    return [...new Set(diarizedSegments.map((s) => s.speaker))];
-  }, [diarizedSegments]);
-
   const filteredTranscript = useMemo(() => {
     if (!transcription || !search.trim()) return transcription;
     return transcription
@@ -875,15 +757,6 @@ function App() {
       .filter((l) => l.toLowerCase().includes(search.toLowerCase()))
       .join("\n");
   }, [transcription, search]);
-
-  const filteredSegments = useMemo(() => {
-    if (!diarizedSegments) return null;
-    if (!search.trim()) return diarizedSegments;
-    return diarizedSegments.filter((s) =>
-      s.text.toLowerCase().includes(search.toLowerCase()) ||
-      s.speaker.toLowerCase().includes(search.toLowerCase())
-    );
-  }, [diarizedSegments, search]);
 
   // Load persisted settings and history on mount
   useEffect(() => {
@@ -971,19 +844,19 @@ function App() {
             setIsRecording(parsed.data.is_recording);
             if (parsed.data.is_recording) {
               setTranscription(""); setNotes("");
-              setDiarizedSegments(null); setMeetingTags([]);
+              setStructuredSummary(null);
               setSelectedMeetingId(null); setActiveTab("transcript");
             }
             break;
           case "PIPELINE_STATUS": setStatus(parsed.data.step); break;
           case "TRANSCRIPTION_COMPLETED":
-            setTranscription(parsed.data.text);
-            setDiarizedSegments(parsed.data.diarized ? (parsed.data.segments ?? null) : null);
-            setActiveTab("transcript");
-            break;
+            setTranscription(parsed.data.text); setActiveTab("transcript"); break;
           case "NOTES_GENERATED": {
             const md = parsed.data.markdown;
-            setNotes(md); setActiveTab("summary");
+            const structured = parsed.data.structured ?? null;
+            setNotes(md);
+            setStructuredSummary(structured && structured.tldr ? structured : null);
+            setActiveTab("summary");
             try {
               await invoke("save_meeting", {
                 date: new Date().toLocaleString(),
@@ -1156,26 +1029,14 @@ function App() {
         <main className="main-content">
           <div className="meeting-header">
             <div className="meeting-header-left">
-              <div className="meeting-title-row">
-                <div className="meeting-title">
-                  {selectedMeetingId
-                    ? meetingsHistory.find((m) => m.id === selectedMeetingId)?.title ?? "Meeting"
-                    : "Current Session"}
-                </div>
-                {participants.length > 0 && (
-                  <ParticipantAvatars speakers={participants} />
-                )}
+              <div className="meeting-title">
+                {selectedMeetingId
+                  ? meetingsHistory.find((m) => m.id === selectedMeetingId)?.title ?? "Meeting"
+                  : "Current Session"}
               </div>
               <div className="meeting-meta">
                 {isRecording ? `Recording · ${formatDuration(recordingSeconds)}` : status}
               </div>
-              {(meetingTags.length > 0 || !selectedMeetingId) && (
-                <TagRow
-                  tags={meetingTags}
-                  onAdd={(t) => setMeetingTags((prev) => [...prev, t])}
-                  onRemove={(t) => setMeetingTags((prev) => prev.filter((x) => x !== t))}
-                />
-              )}
             </div>
             <div className="meeting-header-right">
               {isRecording && <Waveform width={60} height={14} color={waveColor} active bars={14} />}
@@ -1209,37 +1070,93 @@ function App() {
           <div className="tab-content">
             {activeTab === "transcript" && (
               <div className="tab-panel">
-                {filteredSegments ? (
-                  <div className="transcript-diarized">
-                    {filteredSegments.map((seg, i) => (
-                      <TranscriptLine key={i} seg={seg} />
-                    ))}
-                  </div>
-                ) : filteredTranscript ? (
-                  <pre className="transcript-text">{filteredTranscript}</pre>
-                ) : (
-                  <div className="empty-state">
+                {filteredTranscript
+                  ? <pre className="transcript-text">{filteredTranscript}</pre>
+                  : <div className="empty-state">
                     {isRecording
                       ? <><Waveform width={60} height={14} color={waveColor} active bars={14} /><span>Transcribing…</span></>
                       : <span>Start recording to see the transcript here.</span>}
-                  </div>
-                )}
+                  </div>}
               </div>
             )}
             {activeTab === "summary" && (
               <div className="tab-panel">
-                {notes
-                  ? <>{tldr && <div className="tldr-card"><div className="tldr-label">TL;DR</div><p className="tldr-body">{tldr}</p></div>}<pre className="summary-text">{notes}</pre></>
-                  : <div className="empty-state"><span>Summary will appear here once recording is processed.</span></div>}
+                {structuredSummary ? (
+                  <div className="structured-summary">
+                    {/* TL;DR */}
+                    {structuredSummary.tldr && (
+                      <div className="tldr-card">
+                        <div className="tldr-label">TL;DR</div>
+                        <p className="tldr-body">{structuredSummary.tldr}</p>
+                      </div>
+                    )}
+                    {/* Decisions */}
+                    {structuredSummary.decisions.length > 0 && (
+                      <div className="summary-section">
+                        <div className="summary-section-title">Decisions</div>
+                        <ul className="decisions-list">
+                          {structuredSummary.decisions.map((d, i) => (
+                            <li key={i} className="decision-item">
+                              <span className="decision-check">✓</span>
+                              <span>{d}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                    {/* Markdown fallback for Key Takeaways */}
+                    <div className="summary-section">
+                      <div className="summary-section-title">Full Summary</div>
+                      <pre className="summary-text">{structuredSummary.markdown}</pre>
+                    </div>
+                  </div>
+                ) : notes ? (
+                  <>
+                    {tldr && <div className="tldr-card"><div className="tldr-label">TL;DR</div><p className="tldr-body">{tldr}</p></div>}
+                    <pre className="summary-text">{notes}</pre>
+                  </>
+                ) : (
+                  <div className="empty-state"><span>Summary will appear here once recording is processed.</span></div>
+                )}
               </div>
             )}
             {activeTab === "actions" && (
               <div className="tab-panel">
-                {actionItems.length > 0
-                  ? <ul className="action-list">{actionItems.map((item, i) => (
+                {structuredSummary?.actions?.length ? (
+                  <ul className="action-list">
+                    {structuredSummary.actions.map((item, i) => (
+                      <li key={i} className={`action-item-rich ${item.done ? "done" : ""}`}>
+                        <button
+                          className="action-checkbox-btn"
+                          onClick={() => {
+                            setStructuredSummary((prev) => {
+                              if (!prev) return prev;
+                              const actions = prev.actions.map((a, j) =>
+                                j === i ? { ...a, done: !a.done } : a
+                              );
+                              return { ...prev, actions };
+                            });
+                          }}
+                        >
+                          {item.done ? "✓" : ""}
+                        </button>
+                        <div className="action-item-body">
+                          <span className="action-item-text">{item.text}</span>
+                          <div className="action-item-meta">
+                            {item.who && <span className="action-badge action-who">{item.who}</span>}
+                            {item.due && <span className="action-badge action-due">{item.due}</span>}
+                          </div>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                ) : actionItems.length > 0 ? (
+                  <ul className="action-list">{actionItems.map((item, i) => (
                     <li key={i} className="action-item"><span className="action-checkbox" /><span className="action-text">{item}</span></li>
                   ))}</ul>
-                  : <div className="empty-state"><span>{notes ? "No action items found. Use `- [ ] task` format." : "Action items will appear here after processing."}</span></div>}
+                ) : (
+                  <div className="empty-state"><span>{notes ? "No action items found." : "Action items will appear here after processing."}</span></div>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
- Update LangGraph Node 3 to return structured JSON with tldr/decisions/actions/tags/markdown
- Graceful fallback to plain markdown if JSON parse fails
- Emit structured payload in NOTES_GENERATED event
- Add StructuredSummary and ActionItem interfaces in App.tsx
- Render TL;DR card, decisions list, full summary in summary tab
- Rich action items with clickable checkbox, assignee badge, due date badge
- Fallback to legacy markdown-parsed rendering for backward compat