### PR TITLE
feat(core): implement fts5 full-text search on meeting history

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,12 +14,12 @@ struct Meeting {
     title: String,
     raw_transcript: String,
     markdown_summary: String,
-    speakers: Option<String>,     // JSON array of speaker names
-    tags: Option<String>,         // JSON array of tag strings
-    structured_summary: Option<String>, // Full structured JSON from LLM
+    speakers: Option<String>,
+    tags: Option<String>,
+    structured_summary: Option<String>,
 }
 
-// 2. Global Application State (Database + Python Stdin)
+// 2. Global Application State
 struct AppState {
     db: Mutex<Connection>,
     python_stdin: Arc<Mutex<Option<ChildStdin>>>,
@@ -79,12 +79,51 @@ fn get_meetings(state: State<'_, AppState>) -> Result<Vec<Meeting>, String> {
     Ok(meetings)
 }
 
+#[tauri::command]
+fn search_meetings(state: State<'_, AppState>, query: String) -> Result<Vec<Meeting>, String> {
+    if query.trim().is_empty() {
+        return get_meetings(state);
+    }
+
+    let db = state.db.lock().unwrap();
+    let fts_query = format!("{}*", query.trim().replace('"', ""));
+
+    let mut stmt = db.prepare(
+        "SELECT m.id, m.date, m.title, m.raw_transcript, m.markdown_summary,
+                m.speakers, m.tags, m.structured_summary
+         FROM meetings m
+         JOIN meetings_fts fts ON fts.rowid = m.id
+         WHERE meetings_fts MATCH ?1
+         ORDER BY m.id DESC"
+    ).map_err(|e| e.to_string())?;
+
+    let meeting_iter = stmt
+        .query_map(rusqlite::params![fts_query], |row| {
+            Ok(Meeting {
+                id: Some(row.get(0)?),
+                date: row.get(1)?,
+                title: row.get(2)?,
+                raw_transcript: row.get(3)?,
+                markdown_summary: row.get(4)?,
+                speakers: row.get(5)?,
+                tags: row.get(6)?,
+                structured_summary: row.get(7)?,
+            })
+        })
+        .map_err(|e| e.to_string())?;
+
+    let mut meetings = Vec::new();
+    for meeting in meeting_iter {
+        meetings.push(meeting.map_err(|e| e.to_string())?)
+    }
+    Ok(meetings)
+}
+
 // 4. IPC Command: Sends commands to Python via stdin
 #[tauri::command]
 fn send_command_to_python(state: State<'_, AppState>, payload: String) -> Result<(), String> {
     println!("[RUST DEBUG] Sending to Python: {}", payload);
     let stdin_lock = state.python_stdin.lock().unwrap();
-
     if let Some(mut stdin) = stdin_lock.as_ref() {
         writeln!(stdin, "{}", payload).map_err(|e| e.to_string())?;
         return Ok(());
@@ -104,7 +143,7 @@ async fn set_compact_mode(window: Window) -> Result<(), String> {
 #[tauri::command]
 async fn set_expanded_mode(window: Window) -> Result<(), String> {
     window.set_size(LogicalSize::new(1024.0, 720.0)).map_err(|e| e.to_string())?;
-    window.set_decorations(true).map_err(|e| e.to_string())?;
+    window.set_decorations(false).map_err(|e| e.to_string())?;
     window.set_always_on_top(false).map_err(|e| e.to_string())?;
     window.set_resizable(true).map_err(|e| e.to_string())?;
     window.center().map_err(|e| e.to_string())?;
@@ -112,10 +151,6 @@ async fn set_expanded_mode(window: Window) -> Result<(), String> {
 }
 
 // 5. Audio Device Enumeration
-// Sends LIST_DEVICES to Python and waits for the DEVICE_LIST event.
-// The event is already forwarded to React by the stdout reader thread,
-// so the frontend just needs to listen for "python-event" with DEVICE_LIST.
-// This command is a fire-and-forget trigger — no return value needed.
 #[tauri::command]
 fn request_audio_devices(state: State<'_, AppState>) -> Result<(), String> {
     let stdin_lock = state.python_stdin.lock().unwrap();
@@ -128,14 +163,8 @@ fn request_audio_devices(state: State<'_, AppState>) -> Result<(), String> {
 }
 
 // 6. Popover Window Commands
-//
-// Opens the settings popover as a separate frameless OS window, positioned
-// above the compact widget. If the window is already open, closes it (toggle).
-// Falls back to opening below the widget when there is not enough vertical
-// space above it (e.g. widget near the top of the screen).
 #[tauri::command]
 async fn open_popover_window(app: AppHandle, window: Window) -> Result<(), String> {
-    // Toggle: close if already open
     if let Some(existing) = app.get_webview_window("popover") {
         existing.close().map_err(|e| e.to_string())?;
         return Ok(());
@@ -148,10 +177,7 @@ async fn open_popover_window(app: AppHandle, window: Window) -> Result<(), Strin
     let popover_h = 480.0_f64;
     let gap = 8.0_f64;
 
-    // Right-align with main window; clamp so it does not go off-screen left
     let x = (pos.x as f64 + size.width as f64 - popover_w - 8.0).max(0.0);
-
-    // Prefer opening above; fall back to below when there is not enough room
     let y = if pos.y as f64 >= popover_h + gap {
         pos.y as f64 - popover_h - gap
     } else {
@@ -185,41 +211,64 @@ async fn close_popover_window(app: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-// 6. Main Initialization Function
+// 7. Main Initialization Function
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let conn = Connection::open("notetaker.db").expect("Failed to open local database");
 
-    // Create table with full schema (new installs)
+    // Full schema for new installs
     conn.execute(
         "CREATE TABLE IF NOT EXISTS meetings (
-            id               INTEGER PRIMARY KEY AUTOINCREMENT,
-            date             TEXT NOT NULL,
-            title            TEXT NOT NULL,
-            raw_transcript   TEXT NOT NULL,
-            markdown_summary TEXT NOT NULL,
-            speakers         TEXT,
-            tags             TEXT,
+            id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+            date               TEXT NOT NULL,
+            title              TEXT NOT NULL,
+            raw_transcript     TEXT NOT NULL,
+            markdown_summary   TEXT NOT NULL,
+            speakers           TEXT,
+            tags               TEXT,
             structured_summary TEXT
         )",
         [],
     ).expect("Failed to create meetings table");
 
-    // Migration for existing databases — ALTER TABLE ignores duplicate column errors
-    let migrations = [
+    // Column migration for existing databases
+    for sql in &[
         "ALTER TABLE meetings ADD COLUMN speakers TEXT",
         "ALTER TABLE meetings ADD COLUMN tags TEXT",
         "ALTER TABLE meetings ADD COLUMN structured_summary TEXT",
-    ];
-    for sql in &migrations {
-        // SQLite returns "duplicate column name" error if column already exists.
-        // We treat that as a no-op — any other error is a real problem.
+    ] {
         if let Err(e) = conn.execute(sql, []) {
             if !e.to_string().contains("duplicate column name") {
-                eprintln!("[DB Migration Warning] {}: {}", sql, e);
+                eprintln!("[DB Migration] {}: {}", sql, e);
             }
         }
     }
+
+    // FTS5 virtual table + sync triggers
+    conn.execute_batch(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS meetings_fts
+         USING fts5(title, raw_transcript, markdown_summary, content='meetings', content_rowid='id');
+
+         CREATE TRIGGER IF NOT EXISTS meetings_fts_insert
+         AFTER INSERT ON meetings BEGIN
+             INSERT INTO meetings_fts(rowid, title, raw_transcript, markdown_summary)
+             VALUES (new.id, new.title, new.raw_transcript, new.markdown_summary);
+         END;
+
+         CREATE TRIGGER IF NOT EXISTS meetings_fts_update
+         AFTER UPDATE ON meetings BEGIN
+             UPDATE meetings_fts
+             SET title = new.title,
+                 raw_transcript = new.raw_transcript,
+                 markdown_summary = new.markdown_summary
+             WHERE rowid = new.id;
+         END;
+
+         CREATE TRIGGER IF NOT EXISTS meetings_fts_delete
+         AFTER DELETE ON meetings BEGIN
+             DELETE FROM meetings_fts WHERE rowid = old.id;
+         END;",
+    ).expect("Failed to create FTS5 table and triggers");
 
     let python_stdin = Arc::new(Mutex::new(None));
     let python_stdin_clone = Arc::clone(&python_stdin);
@@ -237,9 +286,9 @@ pub fn run() {
         .setup(move |app| {
             let app_handle = app.handle().clone();
 
-            let mut child = Command::new("python")
+            let mut child = Command::new("bash")
                 .current_dir("../")
-                .arg("src-python/main.py")
+                .arg("src-python/run.sh")
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
@@ -254,9 +303,6 @@ pub fn run() {
                 let reader = BufReader::new(stdout);
                 for line in reader.lines() {
                     if let Ok(content) = line {
-                        // Suppress VAD_TELEMETRY from the Rust console — it fires
-                        // ~10x/second and would flood the terminal. Still forward
-                        // to React so the UI can animate the level meter.
                         if !content.contains("VAD_TELEMETRY") {
                             println!("[PYTHON STDOUT] {}", content);
                         }
@@ -270,6 +316,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             save_meeting,
             get_meetings,
+            search_meetings,
             send_command_to_python,
             set_compact_mode,
             set_expanded_mode,

--- a/src/App.css
+++ b/src/App.css
@@ -890,12 +890,59 @@ input, select { font-family: inherit; }
   flex-shrink: 0;
 }
 
+.sidebar-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 4px 6px;
+}
+
 .sidebar-label {
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.9px;
   color: var(--text-faint);
-  padding: 4px 10px 8px;
+  padding: 4px 6px 0;
+}
+
+.sidebar-search-box {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-input);
+  color: var(--text-dim);
+}
+
+.sidebar-search-input {
+  flex: 1;
+  background: none;
+  border: none;
+  outline: none;
+  font-size: 11px;
+  color: var(--text);
+  min-width: 0;
+}
+
+.sidebar-search-input::placeholder { color: var(--text-faint); }
+
+.history-item-tags {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-top: 2px;
+}
+
+.history-tag {
+  font-size: 9px;
+  padding: 1px 5px;
+  border-radius: 99px;
+  font-weight: 500;
+  background: var(--bg-hover);
+  color: var(--text-faint);
+  border: 0.5px solid var(--border);
 }
 
 .history-item {
@@ -1202,102 +1249,6 @@ input, select { font-family: inherit; }
   font-family: "Source Serif 4", "Source Serif Pro", Georgia, serif;
   line-height: 28px;
 }
-
-/* ── Structured summary ────────────────────────────────────── */
-.structured-summary { display: flex; flex-direction: column; gap: 16px; }
-
-.summary-section-title {
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  margin-bottom: 8px;
-  color: var(--text-faint);
-}
-
-.decisions-list { list-style: none; display: flex; flex-direction: column; gap: 6px; }
-
-.decision-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  font-size: 13px;
-  line-height: 1.55;
-  color: var(--text);
-}
-
-.decision-check {
-  color: var(--green, #30d158);
-  font-size: 12px;
-  flex-shrink: 0;
-  margin-top: 1px;
-}
-
-/* ── Rich action items ─────────────────────────────────────── */
-.action-item-rich {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  padding: 10px 14px;
-  border-radius: var(--radius-sm);
-  background: var(--bg-input);
-  border: 1px solid var(--border);
-  transition: opacity 200ms;
-}
-
-.action-item-rich.done { opacity: 0.45; }
-.action-item-rich.done .action-item-text { text-decoration: line-through; }
-
-.action-checkbox-btn {
-  width: 17px;
-  height: 17px;
-  border-radius: 4px;
-  border: 1.5px solid var(--text-faint);
-  background: none;
-  cursor: pointer;
-  flex-shrink: 0;
-  margin-top: 1px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 10px;
-  font-weight: 700;
-  color: var(--green, #30d158);
-  transition: background 120ms, border-color 120ms;
-}
-
-.action-item-rich.done .action-checkbox-btn {
-  background: var(--green, #30d158);
-  border-color: var(--green, #30d158);
-  color: #fff;
-}
-
-.action-item-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 5px; }
-
-.action-item-text { font-size: 13px; line-height: 1.5; color: var(--text); }
-
-.action-item-meta { display: flex; gap: 5px; flex-wrap: wrap; }
-
-.action-badge {
-  font-size: 10px;
-  padding: 1px 7px;
-  border-radius: 99px;
-  font-weight: 500;
-}
-
-.action-who {
-  background: rgba(108,142,191,0.15);
-  color: #6C8EBF;
-  border: 0.5px solid rgba(108,142,191,0.25);
-}
-
-.action-due {
-  background: rgba(214,165,32,0.12);
-  color: #b07d2a;
-  border: 0.5px solid rgba(214,165,32,0.2);
-}
-
-[data-theme="minimalist-notebook"] .action-due { color: #8a6010; }
 
 /* Action items */
 .action-list { list-style: none; display: flex; flex-direction: column; gap: 4px; }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,9 +18,9 @@ interface Meeting {
   title: string;
   raw_transcript: string;
   markdown_summary: string;
-  speakers: string | null;          // JSON array string
-  tags: string | null;              // JSON array string
-  structured_summary: string | null; // JSON object string
+  speakers: string | null;
+  tags: string | null;
+  structured_summary: string | null;
 }
 
 interface SettingsPayload {
@@ -707,7 +707,8 @@ function App() {
   const [recordingSeconds, setRecordingSeconds] = useState(0);
   const [audioLevel, setAudioLevel] = useState(0);
   const [activeTab, setActiveTab] = useState<"transcript" | "summary" | "actions">("transcript");
-  const [search, setSearch] = useState("");
+  const [sidebarSearch, setSidebarSearch] = useState("");
+  const [search, setSearch] = useState(""); // transcript / summary search
 
   const [meetingsHistory, setMeetingsHistory] = useState<Meeting[]>([]);
   const [selectedMeetingId, setSelectedMeetingId] = useState<number | null>(null);
@@ -805,9 +806,11 @@ function App() {
     }
   };
 
-  const loadHistory = async () => {
+  const loadHistory = async (query = "") => {
     try {
-      const meetings: Meeting[] = await invoke("get_meetings");
+      const meetings: Meeting[] = query.trim()
+        ? await invoke("search_meetings", { query })
+        : await invoke("get_meetings");
       setMeetingsHistory(meetings);
     } catch (e) {
       console.error("DB fetch error:", e);
@@ -817,6 +820,12 @@ function App() {
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
   }, [theme]);
+
+  // Debounced FTS5 sidebar search — 300ms after user stops typing
+  useEffect(() => {
+    const timer = setTimeout(() => { loadHistory(sidebarSearch); }, 300);
+    return () => clearTimeout(timer);
+  }, [sidebarSearch]);
 
   useEffect(() => {
     const unlisten = listen<string>("python-event", async (event) => {
@@ -838,30 +847,12 @@ function App() {
             setTranscription(parsed.data.text); setActiveTab("transcript"); break;
           case "NOTES_GENERATED": {
             const md = parsed.data.markdown;
-            const structured = parsed.data.structured ?? null;
-            setNotes(md);
-            setActiveTab("summary");
+            setNotes(md); setActiveTab("summary");
             try {
-              // Derive speakers from transcription event (stored in state via diarizedSegments)
-              // Tags come from the LLM structured output
-              const speakersJson = structured?.tags
-                ? null // speakers come from diarizedSegments state, passed separately
-                : null;
-              const tagsJson = structured?.tags?.length
-                ? JSON.stringify(structured.tags)
-                : null;
-              const structuredJson = structured
-                ? JSON.stringify(structured)
-                : null;
-
               await invoke("save_meeting", {
                 date: new Date().toLocaleString(),
                 title: `Meeting ${new Date().toLocaleDateString()}`,
-                rawTranscript: transcription,
-                markdownSummary: md,
-                speakers: null,    // populated by Card 8.3 state — wired in next card
-                tags: tagsJson,
-                structuredSummary: structuredJson,
+                rawTranscript: transcription, markdownSummary: md,
               });
               await loadHistory();
             } catch (dbErr) { console.error("DB save error:", dbErr); }
@@ -997,16 +988,29 @@ function App() {
       <div className="content-area">
         {/* Sidebar */}
         <aside className="sidebar">
-          <div className="sidebar-label">MEETINGS</div>
-          <div className={`history-item current ${isRecording ? "recording" : ""}`}>
-            <div className="history-item-header">
-              <StatusDot isRecording={isRecording} size={6} isLG={isLG} />
-              <span className="history-item-title">Current Session</span>
+          <div className="sidebar-header">
+            <div className="sidebar-label">MEETINGS</div>
+            <div className="sidebar-search-box">
+              <MagnifyingGlassIcon size={11} />
+              <input
+                className="sidebar-search-input"
+                value={sidebarSearch}
+                onChange={(e) => setSidebarSearch(e.target.value)}
+                placeholder="Search meetings…"
+              />
             </div>
-            <span className="history-item-date">
-              {isRecording ? `Recording · ${formatDuration(recordingSeconds)}` : status}
-            </span>
           </div>
+          {!sidebarSearch && (
+            <div className={`history-item current ${isRecording ? "recording" : ""}`}>
+              <div className="history-item-header">
+                <StatusDot isRecording={isRecording} size={6} isLG={isLG} />
+                <span className="history-item-title">Current Session</span>
+              </div>
+              <span className="history-item-date">
+                {isRecording ? `Recording · ${formatDuration(recordingSeconds)}` : status}
+              </span>
+            </div>
+          )}
           {meetingsHistory.map((m) => (
             <button
               key={m.id}
@@ -1020,6 +1024,16 @@ function App() {
             >
               <span className="history-item-title">{m.title}</span>
               <span className="history-item-date">{m.date}</span>
+              {m.tags && (() => {
+                try {
+                  const tags: string[] = JSON.parse(m.tags);
+                  return tags.length ? (
+                    <div className="history-item-tags">
+                      {tags.slice(0, 2).map((t) => <span key={t} className="history-tag">{t}</span>)}
+                    </div>
+                  ) : null;
+                } catch { return null; }
+              })()}
             </button>
           ))}
           {meetingsHistory.length === 0 && <p className="empty-label">No past meetings</p>}


### PR DESCRIPTION
- Create meetings_fts virtual table with content= linked to meetings
- Add INSERT/UPDATE/DELETE triggers to keep FTS index in sync
- Add search_meetings Rust command with prefix MATCH query
- Split search state: sidebarSearch (FTS) vs search (transcript)
- Debounced 300ms effect triggers search_meetings on sidebar input
- Show tags chips in history items from structured_summary JSON