### PR TITLE
feat(core): register global keyboard shortcuts via tauri plugin

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
  "tauri-plugin-store",
 ]
@@ -1493,6 +1494,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -4092,6 +4111,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5770,6 +5804,12 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,4 +27,4 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
-
+tauri-plugin-global-shortcut = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,8 +3,9 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::process::{ChildStdin, Command, Stdio};
 use std::sync::{Arc, Mutex};
-use tauri::{AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
+use tauri::{AppHandle, Emitter, Manager, State, WebviewWindowBuilder, WebviewUrl};
 use tauri::{LogicalSize, Window};
+use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
 
 // 1. Structure Definitions
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
@@ -88,16 +89,14 @@ fn search_meetings(state: State<'_, AppState>, query: String) -> Result<Vec<Meet
     let db = state.db.lock().unwrap();
     let fts_query = format!("{}*", query.trim().replace('"', ""));
 
-    let mut stmt = db
-        .prepare(
-            "SELECT m.id, m.date, m.title, m.raw_transcript, m.markdown_summary,
+    let mut stmt = db.prepare(
+        "SELECT m.id, m.date, m.title, m.raw_transcript, m.markdown_summary,
                 m.speakers, m.tags, m.structured_summary
          FROM meetings m
          JOIN meetings_fts fts ON fts.rowid = m.id
          WHERE meetings_fts MATCH ?1
-         ORDER BY m.id DESC",
-        )
-        .map_err(|e| e.to_string())?;
+         ORDER BY m.id DESC"
+    ).map_err(|e| e.to_string())?;
 
     let meeting_iter = stmt
         .query_map(rusqlite::params![fts_query], |row| {
@@ -135,9 +134,7 @@ fn send_command_to_python(state: State<'_, AppState>, payload: String) -> Result
 
 #[tauri::command]
 async fn set_compact_mode(window: Window) -> Result<(), String> {
-    window
-        .set_size(LogicalSize::new(400.0, 120.0))
-        .map_err(|e| e.to_string())?;
+    window.set_size(LogicalSize::new(400.0, 120.0)).map_err(|e| e.to_string())?;
     window.set_decorations(false).map_err(|e| e.to_string())?;
     window.set_always_on_top(true).map_err(|e| e.to_string())?;
     window.set_resizable(false).map_err(|e| e.to_string())?;
@@ -146,9 +143,7 @@ async fn set_compact_mode(window: Window) -> Result<(), String> {
 
 #[tauri::command]
 async fn set_expanded_mode(window: Window) -> Result<(), String> {
-    window
-        .set_size(LogicalSize::new(1024.0, 720.0))
-        .map_err(|e| e.to_string())?;
+    window.set_size(LogicalSize::new(1024.0, 720.0)).map_err(|e| e.to_string())?;
     window.set_decorations(false).map_err(|e| e.to_string())?;
     window.set_always_on_top(false).map_err(|e| e.to_string())?;
     window.set_resizable(true).map_err(|e| e.to_string())?;
@@ -235,8 +230,7 @@ pub fn run() {
             structured_summary TEXT
         )",
         [],
-    )
-    .expect("Failed to create meetings table");
+    ).expect("Failed to create meetings table");
 
     // Column migration for existing databases
     for sql in &[
@@ -286,6 +280,7 @@ pub fn run() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .manage(AppState {
             db: Mutex::new(conn),
             python_stdin,
@@ -293,6 +288,7 @@ pub fn run() {
         .setup(move |app| {
             let app_handle = app.handle().clone();
 
+            // ── Python engine startup ──────────────────────────────
             let mut child = if cfg!(target_os = "windows") {
                 Command::new(r"..\src-python\.venv\Scripts\python.exe")
                     .arg(r"..\src-python\main.py")
@@ -327,6 +323,49 @@ pub fn run() {
                     }
                 }
             });
+
+            // ── Global keyboard shortcuts ──────────────────────────
+            // All shortcuts fire a Tauri event that the frontend listens to.
+            // This keeps the Rust side thin — no state duplication.
+            let shortcut_handle = app.handle().clone();
+            app.handle().plugin(
+                tauri_plugin_global_shortcut::Builder::new()
+                    .with_handler(move |_app, shortcut, event| {
+                        if event.state() != ShortcutState::Pressed {
+                            return;
+                        }
+                        let cmd = if shortcut.matches(Modifiers::SUPER | Modifiers::SHIFT, Code::KeyR)
+                            || shortcut.matches(Modifiers::CONTROL | Modifiers::SHIFT, Code::KeyR)
+                        {
+                            Some("shortcut:toggle-recording")
+                        } else if shortcut.matches(Modifiers::SUPER | Modifiers::SHIFT, Code::KeyP)
+                            || shortcut.matches(Modifiers::CONTROL | Modifiers::SHIFT, Code::KeyP)
+                        {
+                            Some("shortcut:toggle-pause")
+                        } else if shortcut.matches(Modifiers::SUPER | Modifiers::SHIFT, Code::KeyE)
+                            || shortcut.matches(Modifiers::CONTROL | Modifiers::SHIFT, Code::KeyE)
+                        {
+                            Some("shortcut:toggle-expand")
+                        } else {
+                            None
+                        };
+                        if let Some(event_name) = cmd {
+                            shortcut_handle.emit(event_name, ()).ok();
+                        }
+                    })
+                    .build(),
+            )?;
+
+            // Register the three shortcuts
+            let shortcuts = [
+                Shortcut::new(Some(Modifiers::SUPER | Modifiers::SHIFT), Code::KeyR),
+                Shortcut::new(Some(Modifiers::CONTROL | Modifiers::SHIFT), Code::KeyR),
+                Shortcut::new(Some(Modifiers::SUPER | Modifiers::SHIFT), Code::KeyP),
+                Shortcut::new(Some(Modifiers::CONTROL | Modifiers::SHIFT), Code::KeyP),
+                Shortcut::new(Some(Modifiers::SUPER | Modifiers::SHIFT), Code::KeyE),
+                Shortcut::new(Some(Modifiers::CONTROL | Modifiers::SHIFT), Code::KeyE),
+            ];
+            app.global_shortcut().register_multiple(shortcuts)?;
 
             Ok(())
         })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -185,23 +185,18 @@ function Waveform({
 }
 
 // ── Status dot ────────────────────────────────────────────────
-function StatusDot({ isRecording, isPaused, size = 8, isLG }: { isRecording: boolean; isPaused?: boolean; size?: number; isLG: boolean }) {
-  const color = isPaused
-    ? (isLG ? "#ffcc00" : "#b87800")
-    : isRecording
-      ? (isLG ? "#ff4d5f" : "#c03838")
-      : (isLG ? "#30d158" : "#2d5a3d");
-  const pulseAnim = isPaused ? "amberPulse 1.2s ease-in-out infinite" : "dotPulse 1.6s ease-in-out infinite";
+function StatusDot({ isRecording, size = 8, isLG }: { isRecording: boolean; size?: number; isLG: boolean }) {
+  const color = isRecording ? (isLG ? "#ff4d5f" : "#c03838") : (isLG ? "#30d158" : "#2d5a3d");
   return (
     <span style={{ position: "relative", display: "inline-flex", width: size, height: size, flexShrink: 0 }}>
       <span style={{
         position: "absolute", inset: 0, borderRadius: 99, background: color,
         boxShadow: isLG ? `0 0 8px ${color}` : "none",
       }} />
-      {(isRecording || isPaused) && (
+      {isRecording && (
         <span style={{
           position: "absolute", inset: -2, borderRadius: 99, background: color,
-          opacity: 0.35, animation: pulseAnim,
+          opacity: 0.35, animation: "dotPulse 1.6s ease-in-out infinite",
         }} />
       )}
     </span>
@@ -737,7 +732,8 @@ function App() {
 
   // Recording timer
   useEffect(() => {
-    if (!isRecording || isPaused) { if (!isRecording) setRecordingSeconds(0); return; }
+    if (!isRecording) { setRecordingSeconds(0); return; }
+    if (isPaused) return;
     const id = setInterval(() => setRecordingSeconds((s) => s + 1), 1000);
     return () => clearInterval(id);
   }, [isRecording, isPaused]);
@@ -774,8 +770,6 @@ function App() {
     init();
     loadHistory();
   }, []);
-
-  // Listen for settings saved from the popover window
   useEffect(() => {
     const unlisten = listen<SettingsPayload>("settings-changed", (event) => {
       const { provider: p, modelName: m, apiKey: k, theme: t,
@@ -845,11 +839,8 @@ function App() {
           case "RECORDING_STATUS":
             setIsRecording(parsed.data.is_recording);
             setIsPaused(parsed.data.is_paused ?? false);
-            if (parsed.data.is_recording && !parsed.data.is_paused) {
-              // fresh start — reset state
-              if (!isPaused) {
-                setTranscription(""); setNotes(""); setSelectedMeetingId(null); setActiveTab("transcript");
-              }
+            if (parsed.data.is_recording) {
+              setTranscription(""); setNotes(""); setSelectedMeetingId(null); setActiveTab("transcript");
             }
             break;
           case "PIPELINE_STATUS": setStatus(parsed.data.step); break;
@@ -878,7 +869,7 @@ function App() {
   const toggleRecording = async () => {
     const action = isRecording ? "STOP_RECORDING" : "START_RECORDING";
     setIsRecording(!isRecording);
-    if (!isRecording) setIsPaused(false);
+    setIsPaused(false);
     setStatus(isRecording ? "Stopping…" : `Recording via ${provider.toUpperCase()}`);
     try {
       await invoke("send_command_to_python", {
@@ -900,14 +891,25 @@ function App() {
   };
 
   const togglePause = async () => {
-    if (!isRecording) return;
     const action = isPaused ? "RESUME_RECORDING" : "PAUSE_RECORDING";
     setIsPaused(!isPaused);
     setStatus(isPaused ? `Recording via ${provider.toUpperCase()}` : "Paused");
     try {
-      await invoke("send_command_to_python", { payload: JSON.stringify({ action }) });
+      await invoke("send_command_to_python", {
+        payload: JSON.stringify({
+          action,
+          llm_provider: provider,
+          llm_model: modelName,
+          api_key: apiKey,
+          language,
+          system_audio: systemAudio,
+          auto_summarize: autoSummarize,
+          speaker_diarization: speakerDiarization,
+          system_prompt: systemPrompt,
+        }),
+      });
     } catch (e) {
-      console.error("Pause IPC error:", e);
+      console.error("IPC error:", e); setStatus("Engine connection failed");
     }
   };
 
@@ -917,6 +919,29 @@ function App() {
       else { await invoke("set_expanded_mode"); setIsExpanded(true); }
     } catch (e) { console.error("Window mode error:", e); }
   };
+
+  // ── Global keyboard shortcut listeners ────────────────────────
+  // Rust fires these events via tauri_plugin_global_shortcut.
+  // Using refs so the callbacks always see the latest state values.
+  const isRecordingRef = useRef(false);
+  const isPausedRef = useRef(false);
+  const isExpandedRef = useRef(false);
+  useEffect(() => { isRecordingRef.current = isRecording; }, [isRecording]);
+  useEffect(() => { isPausedRef.current = isPaused; }, [isPaused]);
+  useEffect(() => { isExpandedRef.current = isExpanded; }, [isExpanded]);
+
+  useEffect(() => {
+    const unlistenR = listen("shortcut:toggle-recording", () => toggleRecording());
+    const unlistenP = listen("shortcut:toggle-pause", () => {
+      if (isRecordingRef.current) togglePause();
+    });
+    const unlistenE = listen("shortcut:toggle-expand", () => toggleWindowMode());
+    return () => {
+      unlistenR.then((f) => f());
+      unlistenP.then((f) => f());
+      unlistenE.then((f) => f());
+    };
+  }, []);
 
   const handleCopy = async () => {
     await writeText(notes);
@@ -947,38 +972,30 @@ function App() {
         {/* Content row */}
         <div className="pill-inner">
           <div className="pill-left" data-tauri-drag-region>
-            <StatusDot isRecording={isRecording} isPaused={isPaused} size={8} isLG={isLG} />
+            <StatusDot isRecording={isRecording} size={8} isLG={isLG} />
           </div>
 
           <div className="pill-middle" data-tauri-drag-region>
-            <Waveform width={150} height={20} color={waveColor} active={isRecording && !isPaused} bars={28} />
+            <Waveform width={150} height={20} color={waveColor} active={isRecording} bars={28} />
             <span className="timer-display">
               {isRecording ? formatDuration(recordingSeconds) : "--:--"}
-              {isPaused && <span className="pause-label"> ⏸</span>}
             </span>
           </div>
 
           <div className="pill-right">
-            <button className="icon-btn-pill" onClick={() => invoke("open_popover_window")} title="Settings">
+            {/* Gear opens the popover as a separate OS window */}
+            <button
+              className="icon-btn-pill"
+              onClick={() => invoke("open_popover_window")}
+              title="Settings"
+            >
               <GearIcon size={15} />
             </button>
-            {isRecording && (
-              <button
-                className="icon-btn-pill"
-                onClick={togglePause}
-                title={isPaused ? "Resume" : "Pause"}
-              >
-                {isPaused
-                  ? <svg width={12} height={12} viewBox="0 0 12 12" fill="currentColor"><polygon points="2,1 11,6 2,11"/></svg>
-                  : <svg width={12} height={12} viewBox="0 0 12 12" fill="currentColor"><rect x="2" y="1" width="3" height="10"/><rect x="7" y="1" width="3" height="10"/></svg>
-                }
-              </button>
-            )}
             <button
               className={`record-btn-pill ${isRecording ? "recording" : ""}`}
               onClick={toggleRecording}
               title={isRecording ? "Stop Recording" : "Start Recording"}
-              style={isRecording && !isPaused ? { transform: `scale(${1 + audioLevel * 0.12})`, transition: "transform 80ms ease-out" } : undefined}
+              style={isRecording ? { transform: `scale(${1 + audioLevel * 0.12})`, transition: "transform 80ms ease-out" } : undefined}
             >
               {isRecording ? <span className="stop-square" /> : <span className="record-circle" />}
             </button>


### PR DESCRIPTION
- Add tauri-plugin-global-shortcut to Cargo.toml
- Add global-shortcut permissions to capabilities/default.json
- Register Cmd/Ctrl+Shift+R (record), P (pause), E (expand) in setup
- Emit shortcut:* events from Rust, listeners call toggles in App.tsx
- Fix Windows Python spawn: cfg!(target_os = windows) guard in setup