### PR TITLE
Chore fix bug on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ __pycache__/
 temp_*.wav
 
 .claude
+
+
+src-tauri/binaries/audio-tap-aarch64-apple-darwin

--- a/src-python/audio_capture.py
+++ b/src-python/audio_capture.py
@@ -449,17 +449,15 @@ class MacosSystemAudioMixer:
 
     @staticmethod
     def _normalize(raw: bytes) -> np.ndarray:
-        """float32 stereo 48kHz → int16 mono 16kHz."""
+        """
+        Normalize Swift tap output to int16 mono 16kHz for mixing with mic.
+        Native format from CATap aggregate device: Float32 mono 44100 Hz.
+        """
         from scipy.signal import resample_poly
-        samples = np.frombuffer(raw, dtype=np.float32)
-        # Reshape to (frames, 2) and downmix to mono
-        if len(samples) % 2 != 0:
-            samples = samples[:-1]
-        stereo = samples.reshape(-1, 2)
-        mono_f32 = stereo.mean(axis=1)
-        # Resample 48kHz → 16kHz (ratio 1:3)
-        mono_16k = resample_poly(mono_f32, 1, 3).astype(np.float32)
-        # Convert float32 → int16
+        mono_f32 = np.frombuffer(raw, dtype=np.float32).copy()
+        # Resample 44100 Hz -> 16000 Hz (ratio 160:441)
+        mono_16k = resample_poly(mono_f32, 160, 441).astype(np.float32)
+        # Convert float32 -> int16
         return (mono_16k * 32768).clip(-32768, 32767).astype(np.int16)
 
     def stop(self) -> np.ndarray | None:

--- a/src-python/audio_capture.py
+++ b/src-python/audio_capture.py
@@ -1,6 +1,7 @@
 # src-python/audio_capture.py
 import sys
 import os
+import subprocess
 import threading
 import wave
 import numpy as np
@@ -60,14 +61,6 @@ class AudioCaptureStrategy(ABC):
         """Stops capturing and returns the absolute path to the saved audio file."""
         pass
 
-    def pause_recording(self):
-        """Pause audio capture — optional, default is no-op."""
-        pass
-
-    def resume_recording(self):
-        """Resume audio capture after pause — optional, default is no-op."""
-        pass
-
 # ---------------------------------------------------------
 # CONCRETE STRATEGIES: OS-specific implementations
 # ---------------------------------------------------------
@@ -80,7 +73,6 @@ class WindowsAudioCapture(AudioCaptureStrategy):
     
     def __init__(self):
         self.is_recording = False
-        self.is_paused = False
         self.telemetry_callback = None
 
         # Audio Engine references
@@ -103,16 +95,6 @@ class WindowsAudioCapture(AudioCaptureStrategy):
 
         current_dir = os.path.dirname(os.path.abspath(__file__))
         self.output_file = os.path.join(current_dir, "temp_meeting_audio.wav")
-
-    def pause_recording(self):
-        """Freeze audio capture — frames are discarded while paused."""
-        self.is_paused = True
-        print("DEBUG: [Windows] Recording paused.", file=sys.stderr)
-
-    def resume_recording(self):
-        """Resume audio capture after pause."""
-        self.is_paused = False
-        print("DEBUG: [Windows] Recording resumed.", file=sys.stderr)
 
     def start_recording(self, telemetry_callback=None):
         if self.is_recording:
@@ -176,14 +158,12 @@ class WindowsAudioCapture(AudioCaptureStrategy):
         try:
             while self.is_recording and self.loopback_stream:
                 data = self.loopback_stream.read(1024, exception_on_overflow=False)
-                if self.is_paused:
-                    continue
                 audio_data = np.frombuffer(data, dtype=np.int16)
-
+                
                 if self.loopback_channels > 1:
                     audio_data = np.reshape(audio_data, (-1, self.loopback_channels))
                     audio_data = np.mean(audio_data, axis=1).astype(np.int16)
-
+                    
                 self.loopback_frames.append(audio_data)
         except Exception as e:
             print(f"DEBUG: [Windows Loopback Error] {str(e)}", file=sys.stderr)
@@ -194,8 +174,6 @@ class WindowsAudioCapture(AudioCaptureStrategy):
         try:
             while self.is_recording and self.mic_stream:
                 data = self.mic_stream.read(1024, exception_on_overflow=False)
-                if self.is_paused:
-                    continue
                 audio_data = np.frombuffer(data, dtype=np.int16)
 
                 if self.mic_channels > 1:
@@ -260,8 +238,9 @@ class WindowsAudioCapture(AudioCaptureStrategy):
     
 class MacosAudioCapture(AudioCaptureStrategy):
     """
-    macOS microphone capture via PyAudio.
-    System audio loopback (ScreenCaptureKit) is planned for Sprint 9 Card 9.4.
+    macOS audio capture:
+    - Microphone via PyAudio (always)
+    - System audio via Core Audio Tap Swift binary (macOS 14.4+, optional)
     """
 
     def __init__(self):
@@ -274,6 +253,7 @@ class MacosAudioCapture(AudioCaptureStrategy):
         self.mic_frames = []
         self.sample_rate = 16000
         self.channels = 1
+        self._sys_mixer = None
 
         current_dir = os.path.dirname(os.path.abspath(__file__))
         self.output_file = os.path.join(current_dir, "temp_meeting_audio.wav")
@@ -286,13 +266,23 @@ class MacosAudioCapture(AudioCaptureStrategy):
         self.is_paused = False
         print("DEBUG: [macOS] Recording resumed.", file=sys.stderr)
 
-    def start_recording(self, telemetry_callback=None):
+    def start_recording(self, telemetry_callback=None, system_audio: bool = False):
         if self.is_recording:
             return
-
         self.is_recording = True
+        self.is_paused = False
         self.telemetry_callback = telemetry_callback
         self.mic_frames = []
+
+        self._sys_mixer = None
+        if system_audio:
+            binary = MacosSystemAudioMixer.find_binary()
+            if binary:
+                mixer = MacosSystemAudioMixer(binary)
+                if mixer.start():
+                    self._sys_mixer = mixer
+            if not self._sys_mixer:
+                print("DEBUG: [macOS] System audio unavailable — mic only.", file=sys.stderr)
 
         try:
             self.p = pyaudio.PyAudio()
@@ -319,8 +309,6 @@ class MacosAudioCapture(AudioCaptureStrategy):
                     continue
                 audio_data = np.frombuffer(data, dtype=np.int16)
                 self.mic_frames.append(audio_data)
-
-                # Emit RMS telemetry every 5th chunk
                 chunk_count += 1
                 if chunk_count % 5 == 0 and self.telemetry_callback:
                     rms = float(np.sqrt(np.mean(audio_data.astype(np.float32) ** 2)))
@@ -332,11 +320,9 @@ class MacosAudioCapture(AudioCaptureStrategy):
     def stop_recording(self) -> str:
         if not self.is_recording:
             return self.output_file
-
         self.is_recording = False
         if self.mic_thread:
             self.mic_thread.join(timeout=2.0)
-
         if self.mic_stream:
             try:
                 self.mic_stream.stop_stream()
@@ -350,17 +336,29 @@ class MacosAudioCapture(AudioCaptureStrategy):
             print("DEBUG: [macOS] No audio frames captured.", file=sys.stderr)
             return self.output_file
 
-        audio_full = np.concatenate(self.mic_frames)
+        mic_full = np.concatenate(self.mic_frames)
+
+        sys_frames = self._sys_mixer.stop() if self._sys_mixer else None
+        self._sys_mixer = None
+
+        if sys_frames is not None and len(sys_frames) > 0:
+            min_len = min(len(mic_full), len(sys_frames))
+            mixed = np.clip(
+                mic_full[:min_len].astype(np.int32) + sys_frames[:min_len].astype(np.int32),
+                -32768, 32767
+            ).astype(np.int16)
+            audio_input = mixed.reshape(-1, 1)
+            print("DEBUG: [macOS] Mixed mic + system audio.", file=sys.stderr)
+        else:
+            audio_input = mic_full.reshape(-1, 1)
 
         print("DEBUG: [AI] Running Silero VAD to trim silence...", file=sys.stderr)
         try:
             vad = VADService()
-            audio_trimmed = vad.trim_silence(
-                audio_full.reshape(-1, 1), self.sample_rate
-            )
+            audio_trimmed = vad.trim_silence(audio_input, self.sample_rate)
         except Exception as e:
             print(f"DEBUG: [AI VAD Error] Falling back to raw audio: {e}", file=sys.stderr)
-            audio_trimmed = audio_full.reshape(-1, 1)
+            audio_trimmed = audio_input
 
         with wave.open(self.output_file, "wb") as wf:
             wf.setnchannels(1)
@@ -385,3 +383,113 @@ class AudioCaptureFactory:
             return MacosAudioCapture()
         else:
             raise NotImplementedError(f"Audio capture is not yet supported on OS: {platform}")
+
+
+# ---------------------------------------------------------
+# macOS SYSTEM AUDIO — Core Audio Tap helper
+# Spawns the Swift binary, reads raw PCM from its stdout,
+# and mixes it with the microphone before passing to VAD.
+# Requires: src-tauri/binaries/audio-tap-{arch}-apple-darwin
+#           built from audio-tap.swift
+# ---------------------------------------------------------
+class MacosSystemAudioMixer:
+    """
+    Reads Float32 stereo 48kHz PCM from the Swift tap binary stdout.
+    Normalizes to int16 mono 16kHz so it can be mixed with the mic stream.
+    Used internally by MacosAudioCapture when system_audio=True.
+    """
+
+    CHUNK = 4096 * 2 * 4  # 4096 frames × 2 ch × 4 bytes (float32)
+
+    def __init__(self, binary_path: str):
+        self.binary_path = binary_path
+        self.proc = None
+        self.thread = None
+        self.frames: list = []
+        self._running = False
+
+    def start(self) -> bool:
+        """Spawn the Swift binary. Returns False if binary not found or old macOS."""
+        if not os.path.exists(self.binary_path):
+            print(f"DEBUG: [CATap] Binary not found: {self.binary_path}", file=sys.stderr)
+            return False
+        try:
+            self.proc = subprocess.Popen(
+                [self.binary_path],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            # Check stderr for READY or FALLBACK_SCKIT
+            stderr_line = self.proc.stderr.readline().decode().strip()
+            if "FALLBACK_SCKIT" in stderr_line:
+                print("DEBUG: [CATap] macOS < 14.4 — system audio unavailable.", file=sys.stderr)
+                self.proc.terminate()
+                return False
+            if "ERROR" in stderr_line:
+                print(f"DEBUG: [CATap] {stderr_line}", file=sys.stderr)
+                self.proc.terminate()
+                return False
+            self._running = True
+            self.thread = threading.Thread(target=self._read_loop, daemon=True)
+            self.thread.start()
+            print("DEBUG: [CATap] System audio capture started.", file=sys.stderr)
+            return True
+        except Exception as e:
+            print(f"DEBUG: [CATap] Failed to start: {e}", file=sys.stderr)
+            return False
+
+    def _read_loop(self):
+        while self._running and self.proc and self.proc.stdout:
+            chunk = self.proc.stdout.read(self.CHUNK)
+            if not chunk:
+                break
+            pcm = self._normalize(chunk)
+            self.frames.append(pcm)
+
+    @staticmethod
+    def _normalize(raw: bytes) -> np.ndarray:
+        """float32 stereo 48kHz → int16 mono 16kHz."""
+        from scipy.signal import resample_poly
+        samples = np.frombuffer(raw, dtype=np.float32)
+        # Reshape to (frames, 2) and downmix to mono
+        if len(samples) % 2 != 0:
+            samples = samples[:-1]
+        stereo = samples.reshape(-1, 2)
+        mono_f32 = stereo.mean(axis=1)
+        # Resample 48kHz → 16kHz (ratio 1:3)
+        mono_16k = resample_poly(mono_f32, 1, 3).astype(np.float32)
+        # Convert float32 → int16
+        return (mono_16k * 32768).clip(-32768, 32767).astype(np.int16)
+
+    def stop(self) -> np.ndarray | None:
+        self._running = False
+        if self.proc and self.proc.stdin:
+            try:
+                self.proc.stdin.write(b"stop\n")
+                self.proc.stdin.flush()
+            except Exception:
+                pass
+        if self.thread:
+            self.thread.join(timeout=2.0)
+        if self.proc:
+            self.proc.terminate()
+        if not self.frames:
+            return None
+        return np.concatenate(self.frames)
+
+    @staticmethod
+    def find_binary() -> str | None:
+        """Locate the Swift binary bundled alongside the app."""
+        import platform as _platform
+        arch = _platform.machine()  # arm64 or x86_64
+        name = f"audio-tap-{arch}-apple-darwin"
+        # When running from Tauri: binary is next to the executable
+        candidates = [
+            os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name),
+            os.path.join(os.path.dirname(os.path.abspath(__file__)), name),
+        ]
+        for p in candidates:
+            if os.path.exists(p):
+                return os.path.abspath(p)
+        return None

--- a/src-python/llm_service.py
+++ b/src-python/llm_service.py
@@ -141,7 +141,6 @@ class MeetingWorkflowEngine:
         try:
             structured = json_lib.loads(raw)
         except Exception:
-            # Fallback: treat the whole response as markdown
             print("DEBUG: [LangGraph] JSON parse failed, falling back to markdown.", file=sys.stderr)
             structured = {
                 "tldr": None,
@@ -150,6 +149,23 @@ class MeetingWorkflowEngine:
                 "tags": [],
                 "markdown": raw,
             }
+
+        # If the model returned empty markdown, build a basic one from the structured fields
+        if not structured.get("markdown"):
+            lines = []
+            if structured.get("tldr"):
+                lines.append(f"## 📝 TL;DR\n{structured['tldr']}\n")
+            if structured.get("decisions"):
+                lines.append("## ✅ Decisions\n" + "\n".join(f"- {d}" for d in structured["decisions"]) + "\n")
+            if structured.get("actions"):
+                items = [
+                    f"- [ ] {a['text']}" + (f" — {a['who']}" if a.get("who") else "")
+                    for a in structured["actions"]
+                    if a.get("text", "").lower() not in ("none identified.", "none.", "none")
+                ]
+                if items:
+                    lines.append("## 🎯 Action Items\n" + "\n".join(items) + "\n")
+            structured["markdown"] = "\n".join(lines) if lines else raw
 
         return {
             "final_markdown": structured.get("markdown", raw),

--- a/src-python/main.py
+++ b/src-python/main.py
@@ -63,24 +63,19 @@ def main():
                 def on_telemetry(level: float):
                     send_event("VAD_TELEMETRY", {"level": round(level, 3)})
 
-                audio_capturer.start_recording(telemetry_callback=on_telemetry)
-
-            elif action == "PAUSE_RECORDING":
-                if hasattr(audio_capturer, 'pause_recording'):
-                    audio_capturer.pause_recording()
-                send_event("RECORDING_STATUS", {"is_recording": True, "is_paused": True})
-
-            elif action == "RESUME_RECORDING":
-                if hasattr(audio_capturer, 'resume_recording'):
-                    audio_capturer.resume_recording()
-                send_event("RECORDING_STATUS", {"is_recording": True, "is_paused": False})
+                audio_capturer.start_recording(
+                    telemetry_callback=on_telemetry,
+                    system_audio=current_config.get("system_audio", False),
+                )
 
             elif action == "STOP_RECORDING":
                 send_event("RECORDING_STATUS", {"is_recording": False})
                 send_event("PIPELINE_STATUS", {"step": "Processing Audio (VAD)..."})
 
+                # STEP A: Stop recording and trim silence
                 saved_file_path = audio_capturer.stop_recording()
 
+                # STEP B: Transcribe audio
                 if transcriber:
                     send_event("PIPELINE_STATUS", {"step": "Transcribing with WhisperX..."})
                     lang = current_config.get("language", "auto")
@@ -94,6 +89,7 @@ def main():
                         "diarized": transcription_result.get("diarized", False),
                     })
 
+                    # STEP C: Generate Notes — only if auto_summarize is enabled
                     if not current_config.get("auto_summarize", True):
                         send_event("PIPELINE_STATUS", {"step": "Done."})
                         continue
@@ -103,7 +99,7 @@ def main():
                     provider_name = current_config.get("llm_provider", "ollama")
                     model_name = current_config.get("llm_model", "llama3")
                     api_key = current_config.get("api_key", "")
-
+                    
                     try:
                         llm = LLMFactory.get_provider(provider_name, model_name)
                         result = llm.generate_notes(
@@ -111,18 +107,9 @@ def main():
                             api_key=api_key,
                             system_prompt=current_config.get("system_prompt", "") or None,
                         )
-
-                        _NULL_ACTIONS = {"none identified.", "none.", "none", "n/a", "n/a."}
-                        structured = result.get("structured", {})
-                        if "actions" in structured:
-                            structured["actions"] = [
-                                a for a in structured["actions"]
-                                if a.get("text", "").strip().lower() not in _NULL_ACTIONS
-                            ]
-
                         send_event("NOTES_GENERATED", {
                             "markdown": result.get("markdown", ""),
-                            "structured": structured,
+                            "structured": result.get("structured", {}),
                         })
                         send_event("PIPELINE_STATUS", {"step": "Done."})
                     except Exception as e:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,3 +28,4 @@ tauri-plugin-clipboard-manager = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-global-shortcut = "2"
+

--- a/src-tauri/binaries/BUILD.md
+++ b/src-tauri/binaries/BUILD.md
@@ -1,0 +1,60 @@
+# Building the audio-tap binary
+
+The `audio-tap.swift` CLI captures system audio via Core Audio Tap (macOS 14.4+)
+and pipes raw PCM to stdout. It must be compiled on macOS before running the app.
+
+## Requirements
+
+- macOS 14.4+ SDK (Xcode 15.3+)
+- Swift compiler (`swiftc`) — included with Xcode Command Line Tools
+
+## Build
+
+Run from this directory (`src-tauri/binaries/`):
+
+```bash
+# Apple Silicon (M1/M2/M3/M4)
+swiftc audio-tap.swift \
+  -o audio-tap-aarch64-apple-darwin \
+  -framework AudioToolbox \
+  -framework AVFoundation \
+  -framework Foundation \
+  -target arm64-apple-macos14.4
+
+# Intel
+swiftc audio-tap.swift \
+  -o audio-tap-x86_64-apple-darwin \
+  -framework AudioToolbox \
+  -framework AVFoundation \
+  -framework Foundation \
+  -target x86_64-apple-macos14.4
+
+# Universal binary (both architectures)
+lipo -create \
+  audio-tap-aarch64-apple-darwin \
+  audio-tap-x86_64-apple-darwin \
+  -output audio-tap-universal-apple-darwin
+```
+
+## Verify
+
+```bash
+./audio-tap-aarch64-apple-darwin &
+PID=$!
+sleep 2
+kill $PID
+```
+
+You should see `READY` on stderr if the build succeeded and the system allows it.
+
+## Notes
+
+- The binary is listed in `tauri.conf.json` under `bundle.externalBin` so Tauri
+  includes it in the app bundle automatically.
+- Tauri expects the binary at `src-tauri/binaries/audio-tap-{arch}-apple-darwin`.
+  The arch string must match the output of `uname -m` on the build machine.
+- No code signing is required for development (`npm run tauri dev`).
+  For distribution builds, the binary must be signed with the same Developer ID
+  as the app.
+- On macOS < 14.4, the binary exits with code 2 and prints `FALLBACK_SCKIT`
+  to stderr. Python detects this and falls back to mic-only capture gracefully.

--- a/src-tauri/binaries/audio-tap.swift
+++ b/src-tauri/binaries/audio-tap.swift
@@ -1,20 +1,11 @@
 // audio-tap.swift
-// Captures system audio via Core Audio Tap (macOS 14.4+) and writes
-// raw PCM (Float32 interleaved stereo, 48kHz) to stdout.
-// Python reads chunks from the process stdout and normalizes before mixing.
-//
-// Build (run from src-tauri/binaries/):
-//   swiftc audio-tap.swift -o audio-tap-aarch64-apple-darwin   # Apple Silicon
-//   swiftc audio-tap.swift -o audio-tap-x86_64-apple-darwin    # Intel
-//
+// Captures system audio via Core Audio Tap (macOS 14.4+).
+// Writes raw PCM (Float32 interleaved stereo, 48kHz) to stdout.
 // Send "stop\n" to stdin to terminate cleanly.
 
 import AudioToolbox
 import AVFoundation
 import Foundation
-
-let kSampleRate: Double = 48000
-let kChannels: UInt32 = 2
 
 var tapRef: AudioObjectID = kAudioObjectUnknown
 var aggDevRef: AudioObjectID = kAudioObjectUnknown
@@ -30,17 +21,14 @@ func writePCM(_ buffer: AVAudioPCMBuffer) {
         }
     }
     interleaved.withUnsafeBytes { ptr in
-        _ = ptr.baseAddress.map {
-            FileHandle.standardOutput.write(Data($0, count: ptr.count))
-        }
+        FileHandle.standardOutput.write(Data(bytes: ptr.baseAddress!, count: ptr.count))
     }
 }
 
 if #available(macOS 14.4, *) {
-    var tapDesc = CATapDescription(stereoGlobalTapButExcludeProcesses: [])
-    tapDesc.mutedWhenTapped = false
+    let tapDesc = CATapDescription(stereoMixdownOfProcesses: [])
 
-    var err = AudioHardwareCreateProcessTap(&tapDesc, &tapRef)
+    var err = AudioHardwareCreateProcessTap(tapDesc, &tapRef)
     guard err == noErr else {
         fputs("ERROR: AudioHardwareCreateProcessTap \(err)\n", stderr)
         exit(1)
@@ -60,15 +48,48 @@ if #available(macOS 14.4, *) {
     }
 
     let engine = AVAudioEngine()
-    let format = AVAudioFormat(
-        commonFormat: .pcmFormatFloat32,
-        sampleRate: kSampleRate,
-        channels: kChannels,
-        interleaved: true
-    )!
+    let inputNode = engine.inputNode
 
-    engine.inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { buf, _ in
-        writePCM(buf)
+    // Use nil format — let the engine use its native format for the tap.
+    // We convert to Float32 stereo 48kHz using AVAudioConverter below.
+    let nativeFormat = inputNode.inputFormat(forBus: 0)
+    fputs("DEBUG: native format = \(nativeFormat)\n", stderr)
+
+    // Target format: Float32 non-interleaved stereo 48kHz (AVAudioEngine standard)
+    guard let targetFormat = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: 48000,
+        channels: 2,
+        interleaved: false
+    ) else {
+        fputs("ERROR: could not create target format\n", stderr)
+        exit(1)
+    }
+
+    guard let converter = AVAudioConverter(from: nativeFormat, to: targetFormat) else {
+        fputs("ERROR: could not create AVAudioConverter\n", stderr)
+        exit(1)
+    }
+
+    inputNode.installTap(onBus: 0, bufferSize: 4096, format: nativeFormat) { inBuf, _ in
+        let frameCapacity = AVAudioFrameCount(
+            Double(inBuf.frameLength) * targetFormat.sampleRate / nativeFormat.sampleRate
+        ) + 1
+
+        guard let outBuf = AVAudioPCMBuffer(
+            pcmFormat: targetFormat,
+            frameCapacity: frameCapacity
+        ) else { return }
+
+        var error: NSError?
+        converter.convert(to: outBuf, error: &error) { _, outStatus in
+            outStatus.pointee = .haveData
+            return inBuf
+        }
+
+        if error == nil && outBuf.frameLength > 0 {
+            writePCM(outBuf)
+        }
     }
 
     do {
@@ -79,18 +100,16 @@ if #available(macOS 14.4, *) {
         exit(1)
     }
 
-    // Block until "stop" arrives on stdin
     while let line = readLine() {
         if line.trimmingCharacters(in: .whitespaces) == "stop" { break }
     }
 
     engine.stop()
-    engine.inputNode.removeTap(onBus: 0)
+    inputNode.removeTap(onBus: 0)
     AudioHardwareDestroyAggregateDevice(aggDevRef)
     AudioHardwareDestroyProcessTap(tapRef)
 
 } else {
-    // Signal Python to fall back to ScreenCaptureKit path
     fputs("FALLBACK_SCKIT\n", stderr)
     exit(2)
 }

--- a/src-tauri/binaries/audio-tap.swift
+++ b/src-tauri/binaries/audio-tap.swift
@@ -1,0 +1,96 @@
+// audio-tap.swift
+// Captures system audio via Core Audio Tap (macOS 14.4+) and writes
+// raw PCM (Float32 interleaved stereo, 48kHz) to stdout.
+// Python reads chunks from the process stdout and normalizes before mixing.
+//
+// Build (run from src-tauri/binaries/):
+//   swiftc audio-tap.swift -o audio-tap-aarch64-apple-darwin   # Apple Silicon
+//   swiftc audio-tap.swift -o audio-tap-x86_64-apple-darwin    # Intel
+//
+// Send "stop\n" to stdin to terminate cleanly.
+
+import AudioToolbox
+import AVFoundation
+import Foundation
+
+let kSampleRate: Double = 48000
+let kChannels: UInt32 = 2
+
+var tapRef: AudioObjectID = kAudioObjectUnknown
+var aggDevRef: AudioObjectID = kAudioObjectUnknown
+
+func writePCM(_ buffer: AVAudioPCMBuffer) {
+    guard let channelData = buffer.floatChannelData else { return }
+    let frameCount = Int(buffer.frameLength)
+    let channelCount = Int(buffer.format.channelCount)
+    var interleaved = [Float32](repeating: 0, count: frameCount * channelCount)
+    for frame in 0..<frameCount {
+        for ch in 0..<channelCount {
+            interleaved[frame * channelCount + ch] = channelData[ch][frame]
+        }
+    }
+    interleaved.withUnsafeBytes { ptr in
+        _ = ptr.baseAddress.map {
+            FileHandle.standardOutput.write(Data($0, count: ptr.count))
+        }
+    }
+}
+
+if #available(macOS 14.4, *) {
+    var tapDesc = CATapDescription(stereoGlobalTapButExcludeProcesses: [])
+    tapDesc.mutedWhenTapped = false
+
+    var err = AudioHardwareCreateProcessTap(&tapDesc, &tapRef)
+    guard err == noErr else {
+        fputs("ERROR: AudioHardwareCreateProcessTap \(err)\n", stderr)
+        exit(1)
+    }
+
+    let aggDesc: [String: Any] = [
+        kAudioAggregateDeviceNameKey: "AI NoteTaking Tap",
+        kAudioAggregateDeviceUIDKey: "com.opensource.ainotetaker.catap",
+        kAudioAggregateDeviceIsPrivateKey: 1,
+        kAudioAggregateDeviceIsStackedKey: 0,
+        kAudioAggregateDeviceTapListKey: [["uid": tapRef]],
+    ]
+    err = AudioHardwareCreateAggregateDevice(aggDesc as CFDictionary, &aggDevRef)
+    guard err == noErr else {
+        fputs("ERROR: AudioHardwareCreateAggregateDevice \(err)\n", stderr)
+        exit(1)
+    }
+
+    let engine = AVAudioEngine()
+    let format = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: kSampleRate,
+        channels: kChannels,
+        interleaved: true
+    )!
+
+    engine.inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { buf, _ in
+        writePCM(buf)
+    }
+
+    do {
+        try engine.start()
+        fputs("READY\n", stderr)
+    } catch {
+        fputs("ERROR: engine start \(error)\n", stderr)
+        exit(1)
+    }
+
+    // Block until "stop" arrives on stdin
+    while let line = readLine() {
+        if line.trimmingCharacters(in: .whitespaces) == "stop" { break }
+    }
+
+    engine.stop()
+    engine.inputNode.removeTap(onBus: 0)
+    AudioHardwareDestroyAggregateDevice(aggDevRef)
+    AudioHardwareDestroyProcessTap(tapRef)
+
+} else {
+    // Signal Python to fall back to ScreenCaptureKit path
+    fputs("FALLBACK_SCKIT\n", stderr)
+    exit(2)
+}

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,6 +13,9 @@
     "store:default",
     "clipboard-manager:default",
     "dialog:default",
-    "fs:default"
+    "fs:default",
+    "global-shortcut:allow-register",
+    "global-shortcut:allow-unregister",
+    "global-shortcut:allow-is-registered"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -280,7 +280,32 @@ pub fn run() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
-        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
+        .plugin(
+            tauri_plugin_global_shortcut::Builder::new()
+                .with_handler(move |_app, shortcut, event| {
+                    if event.state() != ShortcutState::Pressed {
+                        return;
+                    }
+                    let m = if cfg!(target_os = "macos") {
+                        Modifiers::SUPER | Modifiers::SHIFT
+                    } else {
+                        Modifiers::CONTROL | Modifiers::SHIFT
+                    };
+                    let cmd = if shortcut.matches(m, Code::KeyR) {
+                        Some("shortcut:toggle-recording")
+                    } else if shortcut.matches(m, Code::KeyP) {
+                        Some("shortcut:toggle-pause")
+                    } else if shortcut.matches(m, Code::KeyE) {
+                        Some("shortcut:toggle-expand")
+                    } else {
+                        None
+                    };
+                    if let Some(name) = cmd {
+                        _app.emit(name, ()).ok();
+                    }
+                })
+                .build(),
+        )
         .manage(AppState {
             db: Mutex::new(conn),
             python_stdin,
@@ -325,45 +350,16 @@ pub fn run() {
             });
 
             // ── Global keyboard shortcuts ──────────────────────────
-            // All shortcuts fire a Tauri event that the frontend listens to.
-            // This keeps the Rust side thin — no state duplication.
-            let shortcut_handle = app.handle().clone();
-            app.handle().plugin(
-                tauri_plugin_global_shortcut::Builder::new()
-                    .with_handler(move |_app, shortcut, event| {
-                        if event.state() != ShortcutState::Pressed {
-                            return;
-                        }
-                        let cmd = if shortcut.matches(Modifiers::SUPER | Modifiers::SHIFT, Code::KeyR)
-                            || shortcut.matches(Modifiers::CONTROL | Modifiers::SHIFT, Code::KeyR)
-                        {
-                            Some("shortcut:toggle-recording")
-                        } else if shortcut.matches(Modifiers::SUPER | Modifiers::SHIFT, Code::KeyP)
-                            || shortcut.matches(Modifiers::CONTROL | Modifiers::SHIFT, Code::KeyP)
-                        {
-                            Some("shortcut:toggle-pause")
-                        } else if shortcut.matches(Modifiers::SUPER | Modifiers::SHIFT, Code::KeyE)
-                            || shortcut.matches(Modifiers::CONTROL | Modifiers::SHIFT, Code::KeyE)
-                        {
-                            Some("shortcut:toggle-expand")
-                        } else {
-                            None
-                        };
-                        if let Some(event_name) = cmd {
-                            shortcut_handle.emit(event_name, ()).ok();
-                        }
-                    })
-                    .build(),
-            )?;
-
-            // Register the three shortcuts
+            // Plugin is already initialized above; only register shortcuts here.
+            let modifier = if cfg!(target_os = "macos") {
+                Modifiers::SUPER | Modifiers::SHIFT
+            } else {
+                Modifiers::CONTROL | Modifiers::SHIFT
+            };
             let shortcuts = [
-                Shortcut::new(Some(Modifiers::SUPER | Modifiers::SHIFT), Code::KeyR),
-                Shortcut::new(Some(Modifiers::CONTROL | Modifiers::SHIFT), Code::KeyR),
-                Shortcut::new(Some(Modifiers::SUPER | Modifiers::SHIFT), Code::KeyP),
-                Shortcut::new(Some(Modifiers::CONTROL | Modifiers::SHIFT), Code::KeyP),
-                Shortcut::new(Some(Modifiers::SUPER | Modifiers::SHIFT), Code::KeyE),
-                Shortcut::new(Some(Modifiers::CONTROL | Modifiers::SHIFT), Code::KeyE),
+                Shortcut::new(Some(modifier), Code::KeyR),
+                Shortcut::new(Some(modifier), Code::KeyP),
+                Shortcut::new(Some(modifier), Code::KeyE),
             ];
             app.global_shortcut().register_multiple(shortcuts)?;
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,8 +32,11 @@
     "active": true,
     "targets": "all",
     "macOS": {
-    "entitlements": "entitlements.plist"
-  },
+      "entitlements": "entitlements.plist"
+    },
+    "externalBin": [
+      "binaries/audio-tap"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
f

- Add audio-tap.swift: Swift CLI capturing system audio via CATapDescription
- Fix format mismatch: use native inputNode format + AVAudioConverter pipeline
- Fix compile errors: CATapDescription is a class, removed mutedWhenTapped, fixed Data(bytes:)
- Native format is Float32 mono 44100 Hz — normalize via resample_poly(160, 441)
- Add MacosSystemAudioMixer: spawns Swift binary, reads PCM from stdout in thread
- Mix mic + system audio with int32 intermediate to prevent overflow
- MacosAudioCapture.start_recording accepts system_audio flag
- Add externalBin to tauri.conf.json, placeholder .exe for Windows builds
- Add BUILD.md with swiftc compilation instructions
- Fix global-shortcut plugin: move from setup() to main plugin chain for macOS compat