### PR TITLE
release: prepare macOS v0.2.1 preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev build-essential curl wget file libssl-dev libayatana-appindicator3-dev librsvg2-dev
 
+      - name: Install Audio Dependencies (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install portaudio
+
       - name: Install Frontend Dependencies
         run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
-            platform: linux
-          - os: macos-latest
+          - os: macos-15
             platform: macos
+            rust_target: aarch64-apple-darwin
+            swift_target: arm64-apple-macos14.4
+            tauri_args: '--target aarch64-apple-darwin'
+          - os: macos-15-intel
+            platform: macos
+            rust_target: x86_64-apple-darwin
+            swift_target: x86_64-apple-macos14.4
+            tauri_args: '--target x86_64-apple-darwin'
           - os: windows-latest
             platform: windows
+            tauri_args: ''
 
     steps:
       - name: Checkout Repository
@@ -31,10 +38,10 @@ jobs:
           node-version: 20
           cache: 'npm'
 
-      - name: Setup Python (3.11)
+      - name: Setup Python (3.12)
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
 
       - name: Setup Rust Stable
@@ -46,16 +53,15 @@ jobs:
           workspaces: src-tauri -> target
 
       # ── 2. Install Dependencies ────────────────────────────────────
-      - name: Install System Dependencies (Linux)
-        if: matrix.platform == 'linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev build-essential curl wget file libssl-dev libayatana-appindicator3-dev librsvg2-dev
+      - name: Install Audio Dependencies (macOS)
+        if: matrix.platform == 'macos'
+        run: brew install portaudio
 
       - name: Install Frontend Dependencies
         run: npm ci
 
       - name: Install Python Dependencies
+        if: matrix.platform == 'macos'
         run: |
           python -m pip install --upgrade pip
           pip install -r src-python/requirements.txt -r src-python/requirements-dev.txt pyinstaller
@@ -65,10 +71,18 @@ jobs:
         if: matrix.platform == 'windows'
         shell: pwsh
         run: |
-          cd src-python
-          pyinstaller build.spec
-          New-Item -ItemType Directory -Force -Path ../src-tauri/binaries
-          Copy-Item -Path dist/ai-notetaking-engine.exe -Destination ../src-tauri/binaries/ai-notetaking-engine-x86_64-pc-windows-msvc.exe -Force
+          ./scripts/build-windows-sidecar.ps1 -Python python
+          ./scripts/build-windows-sidecar-gpu.ps1 -Python python
+
+      - name: Prepare Windows Engine Release Assets
+        if: matrix.platform == 'windows'
+        shell: bash
+        env:
+          ENGINE_VERSION: '0.2.1'
+          ENGINE_RELEASE_BASE: https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}
+        run: |
+          node scripts/split-engine-release-asset.mjs src-tauri/binaries/ai-notetaking-engine-windows-x64-gpu.exe
+          npm run engine:manifest
 
       - name: Build Python Sidecar (macOS)
         if: matrix.platform == 'macos'
@@ -76,44 +90,69 @@ jobs:
           cd src-python
           pyinstaller build.spec
           mkdir -p ../src-tauri/binaries
-          cp dist/ai-notetaking-engine ../src-tauri/binaries/ai-notetaking-engine-x86_64-apple-darwin
-          cp dist/ai-notetaking-engine ../src-tauri/binaries/ai-notetaking-engine-aarch64-apple-darwin
+          cp dist/ai-notetaking-engine "../src-tauri/binaries/ai-notetaking-engine-${{ matrix.rust_target }}"
 
-      - name: Build Python Sidecar (Linux)
-        if: matrix.platform == 'linux'
+      - name: Build Core Audio Tap (macOS)
+        if: matrix.platform == 'macos'
         run: |
-          cd src-python
-          pyinstaller build.spec
-          mkdir -p ../src-tauri/binaries
-          cp dist/ai-notetaking-engine ../src-tauri/binaries/ai-notetaking-engine-x86_64-unknown-linux-gnu
+          swiftc src-tauri/binaries/audio-tap.swift \
+            -o "src-tauri/binaries/audio-tap-${{ matrix.rust_target }}" \
+            -framework AudioToolbox \
+            -framework AVFoundation \
+            -framework Foundation \
+            -target "${{ matrix.swift_target }}"
 
       # ── 4. Tauri Compilation and GitHub Release Upload ─────────────
       - name: Build Tauri Release Bundles
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: npm run tauri build
+        run: npm run tauri build -- ${{ matrix.tauri_args }}
 
       - name: Create Draft Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release view "${{ github.ref_name }}" >/dev/null 2>&1 || gh release create "${{ github.ref_name }}" \
-            --draft \
-            --title "AI NoteTaking ${{ github.ref_name }}" \
-            --notes "Production release ${{ github.ref_name }} for AI Notetaker."
+          if ! gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
+            gh release create "${{ github.ref_name }}" \
+              --draft \
+              --title "AI NoteTaking ${{ github.ref_name }} Preview" \
+              --notes "Preview release ${{ github.ref_name }}. macOS builds use ad-hoc signing and may require manual Gatekeeper approval." \
+              || gh release view "${{ github.ref_name }}" >/dev/null
+          fi
 
       - name: Upload Tauri Release Bundles
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mapfile -d '' assets < <(find src-tauri/target/release/bundle -type f \
-            \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' -o -name '*.dmg' -o -name '*.msi' -o -name '*.exe' -o -name '*.json' \) \
-            -print0)
+          assets=()
+          while IFS= read -r -d '' asset; do
+            assets+=("${asset}")
+          done < <(find src-tauri/target -type f -path '*/release/bundle/*' \
+            \( -name '*.dmg' -o -name '*.msi' -o -name '*.exe' -o -name '*.json' \) -print0)
           if [ "${#assets[@]}" -eq 0 ]; then
             echo "No Tauri bundle assets found."
-            find src-tauri/target/release -maxdepth 4 -type f
+            find src-tauri/target -maxdepth 6 -type f
             exit 1
+          fi
+          gh release upload "${{ github.ref_name }}" "${assets[@]}" --clobber
+
+      - name: Upload Windows Engine Variants
+        if: matrix.platform == 'windows'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cpu=src-tauri/binaries/ai-notetaking-engine-windows-x64-cpu.exe
+          gpu=src-tauri/binaries/ai-notetaking-engine-windows-x64-gpu.exe
+          manifest=src-tauri/binaries/engines-manifest.json
+          shopt -s nullglob
+          gpu_parts=("${gpu}".part*)
+          assets=("${cpu}" "${manifest}")
+          if [ "${#gpu_parts[@]}" -gt 0 ]; then
+            assets+=("${gpu_parts[@]}")
+          else
+            assets+=("${gpu}")
           fi
           gh release upload "${{ github.ref_name }}" "${assets[@]}" --clobber

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: "Igor"
 repository-code: "https://github.com/Igor-C-Assuncao/IA-notetaking"
 license: Apache-2.0
-version: 0.2.0
+version: 0.2.1
 abstract: "An open-source, invisible, privacy-first AI notetaker for meetings. Captures microphone and system (loopback) audio, then generates transcripts and structured summaries locally."
 keywords:
   - meeting-notes
@@ -15,4 +15,4 @@ keywords:
   - whisperx
   - tauri
   - local-first
-date-released: 2026-03-25
+date-released: 2026-07-11

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
   <p>An open-source, invisible, privacy-first AI notetaker for your meetings.</p>
 
-  [![Version](https://img.shields.io/badge/Version-0.2.0-informational.svg)](https://github.com/Igor-C-Assuncao/IA-notetaking/releases)
+  [![Version](https://img.shields.io/badge/Version-0.2.1_preview-informational.svg)](https://github.com/Igor-C-Assuncao/IA-notetaking/releases)
   [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
   [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
   [![Tauri](https://img.shields.io/badge/Tauri_2-App-FFC131?logo=tauri&logoColor=white)](https://tauri.app/)
@@ -177,7 +177,14 @@ meeting fixtures, and larger LLM-generated QMSum runs are still required.
 
 ## Release history
 
-### 0.2.0 (current)
+### 0.2.1 preview (current)
+
+- Preview DMGs for Apple Silicon and Intel Macs
+- Bundles the Python AI engine and native Core Audio Tap helper correctly
+- Windows installer offers verified CPU or NVIDIA/CUDA engine downloads during first-run setup
+- Ad-hoc signed distribution for early macOS testing; Gatekeeper may require manual approval
+
+### 0.2.0
 
 - Meeting briefing intelligence pipeline and briefing dashboard UI
 - Cross-meeting continuity reports, follow-up drafts, chapters, participation signals, risks, open questions, and richer structured summaries

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-notetaking",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-notetaking",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@tauri-apps/api": "2.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-notetaking",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Igor Cassimiro Assunção",

--- a/scripts/create-engine-release-manifest.mjs
+++ b/scripts/create-engine-release-manifest.mjs
@@ -7,7 +7,8 @@ import path from "node:path";
 const repoRoot = process.cwd();
 const binariesDir = path.resolve(repoRoot, "src-tauri", "binaries");
 const releaseBase = process.env.ENGINE_RELEASE_BASE ||
-  "https://github.com/Igor-C-Assuncao/IA-notetaking/releases/download/v0.1.0";
+  "https://github.com/Igor-C-Assuncao/IA-notetaking/releases/download/v0.2.1";
+const engineVersion = process.env.ENGINE_VERSION || "0.2.1";
 const maxSingleAssetBytes = Number(process.env.ENGINE_MAX_SINGLE_ASSET_BYTES || 2_000_000_000);
 
 const candidates = [
@@ -79,7 +80,7 @@ if (engines.length === 0) {
 }
 
 const manifest = {
-  version: "0.1.0",
+  version: engineVersion,
   platform: "windows-x64",
   engines,
 };

--- a/scripts/split-engine-release-asset.mjs
+++ b/scripts/split-engine-release-asset.mjs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Igor Cassimiro Assunção
+import fs from "node:fs";
+import path from "node:path";
+
+const [inputArg, chunkSizeArg = "1900000000"] = process.argv.slice(2);
+if (!inputArg) {
+  console.error("Usage: node scripts/split-engine-release-asset.mjs <file> [chunk-size-bytes]");
+  process.exit(1);
+}
+
+const inputPath = path.resolve(inputArg);
+const chunkSize = Number(chunkSizeArg);
+const size = fs.statSync(inputPath).size;
+if (!Number.isSafeInteger(chunkSize) || chunkSize <= 0) {
+  throw new Error(`Invalid chunk size: ${chunkSizeArg}`);
+}
+if (size <= chunkSize) {
+  console.log(`[engine-split] ${path.basename(inputPath)} fits in one GitHub asset (${size} bytes).`);
+  process.exit(0);
+}
+
+const input = fs.openSync(inputPath, "r");
+const buffer = Buffer.allocUnsafe(8 * 1024 * 1024);
+let offset = 0;
+let part = 1;
+try {
+  while (offset < size) {
+    const outputPath = `${inputPath}.part${String(part).padStart(2, "0")}`;
+    const output = fs.openSync(outputPath, "w");
+    let written = 0;
+    try {
+      while (written < chunkSize && offset < size) {
+        const requested = Math.min(buffer.length, chunkSize - written, size - offset);
+        const read = fs.readSync(input, buffer, 0, requested, offset);
+        if (read === 0) break;
+        fs.writeSync(output, buffer, 0, read);
+        written += read;
+        offset += read;
+      }
+    } finally {
+      fs.closeSync(output);
+    }
+    console.log(`[engine-split] Wrote ${path.basename(outputPath)} (${written} bytes).`);
+    part += 1;
+  }
+} finally {
+  fs.closeSync(input);
+}

--- a/src-python/audio_capture.py
+++ b/src-python/audio_capture.py
@@ -915,6 +915,7 @@ class MacosSystemAudioMixer:
         name = f"audio-tap-{arch}-apple-darwin"
         # When running from Tauri: binary is next to the executable
         candidates = [
+            os.path.join(os.path.dirname(os.path.abspath(sys.executable)), name),
             os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name),
             os.path.join(os.path.dirname(os.path.abspath(__file__)), name),
         ]

--- a/src-python/requirements-runtime.txt
+++ b/src-python/requirements-runtime.txt
@@ -1,4 +1,5 @@
 pyaudiowpatch==0.2.12.8; sys_platform == "win32"
+pyaudio; sys_platform == "darwin"
 soundcard; sys_platform == "linux"
 numpy==2.4.4
 openai==2.31.0

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ai-notetaking"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ai-notetaking"
-version = "0.2.0"
+version = "0.2.1"
 description = "Open-source, privacy-first AI notetaker for meetings (Tauri 2 + Rust + Python)"
 authors = ["Igor Cassimiro Assunção"]
 license = "Apache-2.0"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,9 +83,9 @@ struct AppState {
     supervisor_gen: Arc<AtomicU64>,
 }
 
-const ENGINE_VERSION: &str = "0.1.0";
+const ENGINE_VERSION: &str = "0.2.1";
 const ENGINE_RELEASE_BASE: &str =
-    "https://github.com/Igor-C-Assuncao/IA-notetaking/releases/download/v0.1.0";
+    "https://github.com/Igor-C-Assuncao/IA-notetaking/releases/download/v0.2.1";
 const ENGINE_MANIFEST_FILE: &str = "engines-manifest.json";
 
 #[derive(serde::Serialize)]
@@ -208,6 +208,25 @@ fn find_downloaded_engine(app: &AppHandle, kind: &str) -> Option<PathBuf> {
     }
 }
 
+fn find_bundled_engine(app: &AppHandle) -> Option<PathBuf> {
+    let resource_dir = app.path().resource_dir().ok()?;
+    [resource_dir.clone(), resource_dir.join("binaries")]
+        .into_iter()
+        .filter_map(|directory| std::fs::read_dir(directory).ok())
+        .flat_map(|entries| entries.filter_map(Result::ok))
+        .map(|entry| entry.path())
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.starts_with("ai-notetaking-engine"))
+                .unwrap_or(false)
+                && path
+                    .metadata()
+                    .map(|metadata| metadata.len() > 0)
+                    .unwrap_or(false)
+        })
+}
+
 #[tauri::command]
 fn get_engine_status(app: AppHandle, kind: Option<String>) -> Result<EngineStatus, String> {
     let kind = kind.unwrap_or_else(|| "cpu".to_string());
@@ -223,7 +242,7 @@ fn get_engine_status(app: AppHandle, kind: Option<String>) -> Result<EngineStatu
         });
     }
 
-    let path = find_downloaded_engine(&app, &kind);
+    let path = find_downloaded_engine(&app, &kind).or_else(|| find_bundled_engine(&app));
     let size_bytes = path
         .as_ref()
         .and_then(|p| p.metadata().ok().map(|metadata| metadata.len()));
@@ -242,6 +261,11 @@ fn get_engine_status(app: AppHandle, kind: Option<String>) -> Result<EngineStatu
 fn download_engine(app: AppHandle, kind: String) -> Result<EngineStatus, String> {
     if cfg!(debug_assertions) {
         return get_engine_status(app, Some(kind));
+    }
+    if !cfg!(target_os = "windows") {
+        return Err(
+            "This platform uses the transcription engine bundled with the installer.".to_string(),
+        );
     }
 
     let target_dir = engine_dir(&app, &kind)?;
@@ -1648,6 +1672,7 @@ fn start_sidecar(
     } else {
         Some(
             find_downloaded_engine(&app, &kind)
+                .or_else(|| find_bundled_engine(&app))
                 .ok_or_else(|| format!("{} engine is not installed.", kind))?,
         )
     };

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ai-notetaking",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.opensource.ainotetaker",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "bundle": {
-    "externalBin": ["binaries/audio-tap"]
+    "externalBin": [
+      "binaries/ai-notetaking-engine",
+      "binaries/audio-tap"
+    ]
   }
 }

--- a/src/features/onboarding/OnboardingWizard.tsx
+++ b/src/features/onboarding/OnboardingWizard.tsx
@@ -81,7 +81,7 @@ export function OnboardingWizard() {
         engineKind: wizardState.engineKind || "cpu",
         engineInstalled: Boolean(wizardState.engineInstalled),
         enginePath: wizardState.enginePath || "",
-        engineVersion: "0.1.0",
+        engineVersion: "0.2.1",
         onboarding_completed: true,
       });
 


### PR DESCRIPTION
## What changed

- bumps the desktop application and engine metadata to `0.2.1`
- builds ad-hoc macOS preview DMGs for Apple Silicon and Intel
- bundles the native macOS Python engine and Core Audio Tap helper per architecture
- builds a lightweight Windows installer plus separate CPU and NVIDIA/CUDA engines
- splits oversized GPU assets for GitHub Releases and generates a SHA-256 manifest
- points first-run engine downloads at the `v0.2.1` release
- allows packaged macOS builds to discover their bundled engine and audio helper

## Why

The previous release workflow copied one macOS binary under two architecture names, did not compile the Core Audio Tap helper, and still pointed runtime downloads at `v0.1.0`. The Windows installer also did not publish both selectable engine variants.

## Validation

- `npm test` — 52 tests passed
- `npm run build`
- `cargo test` — 3 tests passed
- `cargo fmt --check`
- release workflow YAML parsed successfully
- release manifest and asset-splitting scripts pass Node syntax checks

## Release behavior

The tag workflow creates a draft preview release. macOS artifacts use ad-hoc signing and may require manual Gatekeeper approval. Windows users choose CPU or NVIDIA/CUDA during first-run setup; downloads are validated against the generated manifest.
