### PR TITLE
release: limit macOS preview to Apple Silicon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,6 @@ jobs:
             rust_target: aarch64-apple-darwin
             swift_target: arm64-apple-macos14.4
             tauri_args: '--target aarch64-apple-darwin'
-          - os: macos-15-intel
-            platform: macos
-            rust_target: x86_64-apple-darwin
-            swift_target: x86_64-apple-macos14.4
-            tauri_args: '--target x86_64-apple-darwin'
           - os: windows-latest
             platform: windows
             tauri_args: ''

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ meeting fixtures, and larger LLM-generated QMSum runs are still required.
 
 ### 0.2.1 preview (current)
 
-- Preview DMGs for Apple Silicon and Intel Macs
+- Preview DMG for Apple Silicon Macs with CPU and Metal/MPS acceleration
 - Bundles the Python AI engine and native Core Audio Tap helper correctly
 - Windows installer offers verified CPU or NVIDIA/CUDA engine downloads during first-run setup
 - Ad-hoc signed distribution for early macOS testing; Gatekeeper may require manual approval


### PR DESCRIPTION
Removes the macOS Intel release job because PyTorch 2.8 does not publish x86_64 macOS wheels. Keeps the v0.2.1 preview focused on Apple Silicon CPU/MPS plus the Windows installer and CPU/CUDA engine variants.\n\nValidation: release workflow YAML parses successfully and the prior Apple Silicon CI job passed.