### PR TITLE
fix macOS release tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     name: Build & Publish Release (${{ matrix.platform }})

--- a/src-tauri/binaries/audio-tap.swift
+++ b/src-tauri/binaries/audio-tap.swift
@@ -31,16 +31,16 @@ func writePCM(_ buffer: AVAudioPCMBuffer) {
     }
     interleaved.withUnsafeBytes { ptr in
         _ = ptr.baseAddress.map {
-            FileHandle.standardOutput.write(Data($0, count: ptr.count))
+            FileHandle.standardOutput.write(Data(bytes: $0, count: ptr.count))
         }
     }
 }
 
 if #available(macOS 14.4, *) {
     var tapDesc = CATapDescription(stereoGlobalTapButExcludeProcesses: [])
-    tapDesc.mutedWhenTapped = false
+    tapDesc.muteBehavior = .unmuted
 
-    var err = AudioHardwareCreateProcessTap(&tapDesc, &tapRef)
+    var err = AudioHardwareCreateProcessTap(tapDesc, &tapRef)
     guard err == noErr else {
         fputs("ERROR: AudioHardwareCreateProcessTap \(err)\n", stderr)
         exit(1)


### PR DESCRIPTION
Fix the macOS release failure in the Core Audio Tap build and restore release publication permissions.

What changed:
- Updated `audio-tap.swift` to use the current Core Audio Tap API.
- Fixed the PCM write helper to use the correct `Data(bytes:count:)` initializer.
- Added `permissions: contents: write` to the release workflow so `gh release create` and asset uploads can work with `GITHUB_TOKEN`.

Validation:
- Ran `xcrun swiftc -typecheck src-tauri/binaries/audio-tap.swift -target arm64-apple-macos14.4 -framework AudioToolbox -framework AVFoundation -framework Foundation`.
- The check passed; only a non-blocking warning about `tapDesc` being unused/mutable remained.