### PR TITLE
fix release workflow shell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,7 @@ jobs:
         run: npm run tauri build -- ${{ matrix.tauri_args }}
 
       - name: Create Draft Release
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## What changed\n\nRun the draft release creation step with Bash on every runner.\n\n## Why\n\nThe Windows runner uses PowerShell by default, so the Bash conditional failed to parse before the Windows installer and CPU/GPU assets could upload.\n\n## Validation\n\nThe macOS job already completed successfully and uploaded the DMG; this fix targets the Windows job.