### PR TITLE
Fix macOS transcription engine bootstrap

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,7 @@ struct EngineStatus {
     path: Option<String>,
     size_bytes: Option<u64>,
     dev_mode: bool,
+    download_supported: bool,
 }
 
 #[derive(serde::Deserialize)]
@@ -210,21 +211,29 @@ fn find_downloaded_engine(app: &AppHandle, kind: &str) -> Option<PathBuf> {
 
 fn find_bundled_engine(app: &AppHandle) -> Option<PathBuf> {
     let resource_dir = app.path().resource_dir().ok()?;
-    [resource_dir.clone(), resource_dir.join("binaries")]
-        .into_iter()
-        .filter_map(|directory| std::fs::read_dir(directory).ok())
-        .flat_map(|entries| entries.filter_map(Result::ok))
-        .map(|entry| entry.path())
-        .find(|path| {
-            path.file_name()
-                .and_then(|name| name.to_str())
-                .map(|name| name.starts_with("ai-notetaking-engine"))
+    let executable_dir = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(PathBuf::from));
+    [
+        Some(resource_dir.clone()),
+        Some(resource_dir.join("binaries")),
+        executable_dir,
+    ]
+    .into_iter()
+    .flatten()
+    .filter_map(|directory| std::fs::read_dir(directory).ok())
+    .flat_map(|entries| entries.filter_map(Result::ok))
+    .map(|entry| entry.path())
+    .find(|path| {
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name.starts_with("ai-notetaking-engine"))
+            .unwrap_or(false)
+            && path
+                .metadata()
+                .map(|metadata| metadata.len() > 0)
                 .unwrap_or(false)
-                && path
-                    .metadata()
-                    .map(|metadata| metadata.len() > 0)
-                    .unwrap_or(false)
-        })
+    })
 }
 
 #[tauri::command]
@@ -239,6 +248,7 @@ fn get_engine_status(app: AppHandle, kind: Option<String>) -> Result<EngineStatu
             path: None,
             size_bytes: None,
             dev_mode: true,
+            download_supported: cfg!(target_os = "windows"),
         });
     }
 
@@ -254,6 +264,7 @@ fn get_engine_status(app: AppHandle, kind: Option<String>) -> Result<EngineStatu
         path: path.map(|p| p.to_string_lossy().to_string()),
         size_bytes,
         dev_mode: false,
+        download_supported: cfg!(target_os = "windows"),
     })
 }
 
@@ -263,9 +274,12 @@ fn download_engine(app: AppHandle, kind: String) -> Result<EngineStatus, String>
         return get_engine_status(app, Some(kind));
     }
     if !cfg!(target_os = "windows") {
-        return Err(
-            "This platform uses the transcription engine bundled with the installer.".to_string(),
-        );
+        let status = get_engine_status(app, Some(kind))?;
+        return if status.installed {
+            Ok(status)
+        } else {
+            Err("The transcription component included with this installation was not found. Reinstall the application and try again.".to_string())
+        };
     }
 
     let target_dir = engine_dir(&app, &kind)?;

--- a/src/features/bootstrap/EngineBootstrap.tsx
+++ b/src/features/bootstrap/EngineBootstrap.tsx
@@ -19,6 +19,7 @@ interface EngineStatus {
   path?: string | null;
   size_bytes?: number | null;
   dev_mode: boolean;
+  download_supported: boolean;
 }
 
 interface ProgressPayload {
@@ -127,7 +128,9 @@ export function EngineBootstrap({ children }: { children: ReactNode }) {
     return Math.min(100, Math.round((progress.downloadedBytes / progress.totalBytes) * 100));
   }, [progress]);
 
-  const bootstrapVariant: BootstrapVariant = status?.installed === false || phase === "downloading" ? "setup" : "initializing";
+  const downloadSupported = status?.download_supported ?? true;
+  const bootstrapVariant: BootstrapVariant =
+    (status?.installed === false && downloadSupported) || phase === "downloading" ? "setup" : "initializing";
 
   const bootstrapTasks = useMemo(
     () => buildBootstrapTasks(bootstrapVariant, phase, progress?.stage, message, startupSlow, Boolean(error)),
@@ -149,7 +152,11 @@ export function EngineBootstrap({ children }: { children: ReactNode }) {
   });
 
   usePythonEvent("SIDECAR_FAILED", () => {
-    setError("The local transcription component could not start. Try again or switch to CPU.");
+    setError(
+      downloadSupported
+        ? "The local transcription component could not start. Try again or switch to CPU."
+        : "The transcription component included with this installation could not start. Try again or reinstall the application."
+    );
     setPhase("error");
   });
 
@@ -202,8 +209,13 @@ export function EngineBootstrap({ children }: { children: ReactNode }) {
         });
         await startSidecar(kind);
       } else {
-        setPhase("choose");
-        setMessage("Choose how local transcription should run on this computer.");
+        if (nextStatus.download_supported) {
+          setPhase("choose");
+          setMessage("Choose how local transcription should run on this computer.");
+        } else {
+          setError("The transcription component included with this installation was not found. Reinstall the application and try again.");
+          setPhase("error");
+        }
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## What changed

- locate the bundled transcription sidecar in the macOS executable directory used by Tauri
- expose whether runtime engine downloads are supported by the current platform
- show CPU/GPU selection and download actions only on Windows
- replace the misleading bundled-engine error with actionable reinstall guidance

## Why

The macOS installer bundles its transcription engine, but bootstrap only searched resource directories. When the engine was not found there, the UI incorrectly entered the Windows CPU/GPU download flow and invoked a command that rejected non-Windows platforms.

## Impact

macOS installations now start the bundled transcription engine directly without asking users to choose CPU or GPU. Windows keeps the existing runtime engine selection and download flow.

## Validation

- `cargo fmt --check`
- `git diff --check`
- confirmed the obsolete platform error is no longer present
- full frontend and Rust checks were attempted; frontend type checking stalled in the local environment, and Rust requires the release-generated macOS sidecar artifact
