### PR TITLE
Prepare macOS-only v0.2.2 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,26 +4,57 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to create or update
+        required: true
+        type: string
+      platform:
+        description: Platform assets to build
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - macos
+          - windows
 
 permissions:
   contents: write
 
 jobs:
+  select-platforms:
+    name: Select release platforms
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.value }}
+    steps:
+      - id: matrix
+        name: Build platform matrix
+        shell: bash
+        env:
+          PLATFORM: ${{ inputs.platform || 'all' }}
+        run: |
+          macos='{"os":"macos-15","platform":"macos","rust_target":"aarch64-apple-darwin","swift_target":"arm64-apple-macos14.4","tauri_args":"--target aarch64-apple-darwin"}'
+          windows='{"os":"windows-latest","platform":"windows","tauri_args":""}'
+          case "$PLATFORM" in
+            macos) matrix="{\"include\":[$macos]}" ;;
+            windows) matrix="{\"include\":[$windows]}" ;;
+            all) matrix="{\"include\":[$macos,$windows]}" ;;
+            *) echo "Unsupported platform: $PLATFORM"; exit 1 ;;
+          esac
+          echo "value=$matrix" >> "$GITHUB_OUTPUT"
+
   publish:
     name: Build & Publish Release (${{ matrix.platform }})
+    needs: select-platforms
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - os: macos-15
-            platform: macos
-            rust_target: aarch64-apple-darwin
-            swift_target: arm64-apple-macos14.4
-            tauri_args: '--target aarch64-apple-darwin'
-          - os: windows-latest
-            platform: windows
-            tauri_args: ''
+      matrix: ${{ fromJSON(needs.select-platforms.outputs.matrix) }}
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
 
     steps:
       - name: Checkout Repository
@@ -77,7 +108,7 @@ jobs:
         shell: bash
         env:
           ENGINE_VERSION: '0.2.1'
-          ENGINE_RELEASE_BASE: https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}
+          ENGINE_RELEASE_BASE: https://github.com/${{ github.repository }}/releases/download/${{ env.RELEASE_TAG }}
         run: |
           node scripts/split-engine-release-asset.mjs src-tauri/binaries/ai-notetaking-engine-windows-x64-gpu.exe
           npm run engine:manifest
@@ -112,12 +143,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if ! gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
-            gh release create "${{ github.ref_name }}" \
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" \
               --draft \
-              --title "AI NoteTaking ${{ github.ref_name }} Preview" \
-              --notes "Preview release ${{ github.ref_name }}. macOS builds use ad-hoc signing and may require manual Gatekeeper approval." \
-              || gh release view "${{ github.ref_name }}" >/dev/null
+              --target "${{ github.sha }}" \
+              --title "AI NoteTaking $RELEASE_TAG Preview" \
+              --notes "Preview release $RELEASE_TAG. macOS builds use ad-hoc signing and may require manual Gatekeeper approval." \
+              || gh release view "$RELEASE_TAG" >/dev/null
           fi
 
       - name: Upload Tauri Release Bundles
@@ -135,7 +167,7 @@ jobs:
             find src-tauri/target -maxdepth 6 -type f
             exit 1
           fi
-          gh release upload "${{ github.ref_name }}" "${assets[@]}" --clobber
+          gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
 
       - name: Upload Windows Engine Variants
         if: matrix.platform == 'windows'
@@ -154,4 +186,15 @@ jobs:
           else
             assets+=("${gpu}")
           fi
-          gh release upload "${{ github.ref_name }}" "${assets[@]}" --clobber
+          gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
+
+  finalize:
+    name: Publish release
+    needs: publish
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+    steps:
+      - name: Publish pre-release
+        run: gh release edit "$RELEASE_TAG" --repo "${{ github.repository }}" --draft=false --prerelease

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-notetaking",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-notetaking",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@tauri-apps/api": "2.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-notetaking",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Igor Cassimiro Assunção",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ai-notetaking"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ai-notetaking"
-version = "0.2.1"
+version = "0.2.2"
 description = "Open-source, privacy-first AI notetaker for meetings (Tauri 2 + Rust + Python)"
 authors = ["Igor Cassimiro Assunção"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ai-notetaking",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.opensource.ainotetaker",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## What changed

- bump the desktop application version to 0.2.2
- add manual release inputs for the release tag and target platform
- generate a release matrix containing only the requested platform
- publish the draft pre-release after all selected platform jobs finish

## Why

The v0.2.2 patch contains a macOS bootstrap fix and should be distributed without rebuilding or replacing the Windows assets. Previously, every release workflow invocation always created both macOS and Windows jobs.

## Impact

Normal tag-based releases still build every supported platform. Manual releases can now select only macOS, allowing v0.2.2 to contain the Apple Silicon DMG without Windows installers or engine packages.

## Validation

- parsed all modified JSON manifests
- validated the generated macOS matrix contains exactly one macOS job
- `cargo fmt --check`
- `git diff --check`
